### PR TITLE
Flip order of StringIO imports in db_mysqldb.py

### DIFF
--- a/pandokia/db_mysqldb.py
+++ b/pandokia/db_mysqldb.py
@@ -23,9 +23,9 @@ import pandokia.db
 debug = False
 
 try:
-    import io as StringIO
-except ImportError:
     import StringIO
+except ImportError:
+    import io as StringIO
 
 import os
 

--- a/pandokia/helpers/pycode.py
+++ b/pandokia/helpers/pycode.py
@@ -283,7 +283,11 @@ class reporter(object):
 ###
 
 # intentionally not using cStringIO
-import six
+try:
+    import StringIO
+except ImportError:
+    import io as StringIO
+    
 import sys
 
 save_stdout = []
@@ -297,7 +301,7 @@ def snarf_stdout(tagname=None):
     save_stderr.append(sys.stderr)
     save_tagname.append(tagname)
 
-    sys.stdout = sys.stderr = six.StringIO()
+    sys.stdout = sys.stderr = StringIO.StringIO()
 
 
 def end_snarf_stdout(tagname=None):
@@ -322,7 +326,7 @@ def end_snarf_stdout(tagname=None):
 
 def peek_snarfed_stdout():
     'returns current text of snarfed stdout, non-destructively'
-    if isinstance(sys.stdout, six.StringIO):
+    if isinstance(sys.stdout, StringIO.StringIO):
         return sys.stdout.getvalue()
     else:
         return None

--- a/pandokia/helpers/pycode.py
+++ b/pandokia/helpers/pycode.py
@@ -287,7 +287,7 @@ try:
     import StringIO
 except ImportError:
     import io as StringIO
-    
+
 import sys
 
 save_stdout = []

--- a/pandokia/helpers/pycode.py
+++ b/pandokia/helpers/pycode.py
@@ -283,11 +283,7 @@ class reporter(object):
 ###
 
 # intentionally not using cStringIO
-try:
-    import StringIO
-except ImportError:
-    import io as StringIO
-
+import six
 import sys
 
 save_stdout = []
@@ -301,7 +297,7 @@ def snarf_stdout(tagname=None):
     save_stderr.append(sys.stderr)
     save_tagname.append(tagname)
 
-    sys.stdout = sys.stderr = StringIO.StringIO()
+    sys.stdout = sys.stderr = six.StringIO()
 
 
 def end_snarf_stdout(tagname=None):
@@ -326,7 +322,7 @@ def end_snarf_stdout(tagname=None):
 
 def peek_snarfed_stdout():
     'returns current text of snarfed stdout, non-destructively'
-    if isinstance(sys.stdout, StringIO.StringIO):
+    if isinstance(sys.stdout, six.StringIO):
         return sys.stdout.getvalue()
     else:
         return None


### PR DESCRIPTION
Import module six in pycode.py so that StringIO will work in both python 2 and 3 seamlessly.
Since Pandeia (JWST ETC repo) is converting from python 2 to python 3 and will support both versions for a certain period of time, this fix will help Pandeia running tests using Pandokia.