### PR TITLE
Change location of writing 'START' and related info in PDK_LOG

### DIFF
--- a/pandokia/run_file.py
+++ b/pandokia/run_file.py
@@ -236,6 +236,17 @@ def run(dirname, basename, envgetter, runner):
 
         full_filename = dirname + "/" + env['PDK_FILE']
 
+        f = open(env['PDK_LOG'], "a")
+        f.write("\n\nSTART\n")
+        f.write('test_run=%s\n' % env['PDK_TESTRUN'])
+        f.write('project=%s\n' % env['PDK_PROJECT'])
+        f.write('host=%s\n' % env['PDK_HOST'])
+        f.write('location=%s\n' % full_filename)
+        f.write('test_runner=%s\n' % runner)
+        f.write('context=%s\n' % env['PDK_CONTEXT'])
+        f.write("SETDEFAULT\n")
+        f.close()
+
         # fetch the command that executes the tests
         cmd = runner_mod.command(env)
         output_buffer = ''
@@ -333,18 +344,10 @@ def run(dirname, basename, envgetter, runner):
         # that we made all of these log entries for it.
         pdkrun_status(full_filename)
 
-        f = open(env['PDK_LOG'], "a")
-        f.write("\n\nSTART\n")
-        f.write('test_run=%s\n' % env['PDK_TESTRUN'])
-        f.write('project=%s\n' % env['PDK_PROJECT'])
-        f.write('host=%s\n' % env['PDK_HOST'])
-        f.write('location=%s\n' % full_filename)
-        f.write('test_runner=%s\n' % runner)
-        f.write('context=%s\n' % env['PDK_CONTEXT'])
-        f.write("SETDEFAULT\n")
 
         # Trap unhandled exit information
         if return_status > 1 or return_status < 0:
+            f = open(env['PDK_LOG'], "a")
             f.write('\n')
             f.write('test_name=%s\n' % full_filename)
             f.write('status=E\n')
@@ -359,7 +362,7 @@ def run(dirname, basename, envgetter, runner):
                     f.write('.{}\n'.format(line))
                 f.write('\n')
             f.write('END\n')
-        f.close()
+            f.close()
 
         if 1:
             # if the runner did not provide a status summary, collect it from


### PR DESCRIPTION
There is an issue when import test results from log to the Pandokia web page. The results of the first set of test will be missing in Pandokia even though the results are present in the test log. 
It is because the test results are posted before the 'START' block and Pandokia can not relate any test_run associate with the those test results (since the test run is defined after 'START'). Therefore, those results will be missing in Pandokia web page. Example and details in https://github.com/STScI-SSB/pandeia/issues/3865#issuecomment-394691496. 
Since it is caused by an ordering issue, moving the location of the 'START' and related info will fix the problem. 

CC @vglaidler @cslocum 