### PR TITLE
Changing unique index in result_scalar table

### DIFF
--- a/pandokia/check_expected.py
+++ b/pandokia/check_expected.py
@@ -110,7 +110,7 @@ def run(args):
 
     where_text, where_dict = pdk_db.where_dict(select_args)
 
-    s = "SELECT project, host, test_name, context FROM expected %s " % where_text
+    s = "SELECT project, host, test_name, context, test_hash FROM expected %s " % where_text
 
     if verbose > 1:
         print(s)
@@ -132,9 +132,8 @@ def run(args):
             print("CHECK %s %s %s" % (project, host, test_name))
 
         c1 = pdk_db.execute("""SELECT status FROM result_scalar
-                WHERE test_run = :1 AND project = :2 AND host = :3 AND
-                test_name = :4 AND context = :5 """,
-                            (test_run, project, host, test_name, context)
+                WHERE test_hash = :1""",
+                            (test_hash)
                             )
 
         if c1.fetchone() is None:
@@ -143,15 +142,16 @@ def run(args):
                 print("        MISSING: %s %s %s" % (project, host, test_name))
             pdk_db.execute(
                 """INSERT INTO result_scalar
-                ( test_run, project, host, context, test_name, status, attn )
-                VALUES ( :1, :2, :3, :4, :5, :6, :7 )""",
+                ( test_run, project, host, context, test_name, status, attn, test_hash )
+                VALUES ( :1, :2, :3, :4, :5, :6, :7, :8 )""",
                 (test_run,
                  project,
                  host,
                  context,
                  test_name,
                  'M',
-                 'Y'))
+                 'Y',
+                 test_hash))
             detected = detected + 1
 
             # do some commits from time to time to avoid lock timeouts

--- a/pandokia/gen_expected.py
+++ b/pandokia/gen_expected.py
@@ -65,7 +65,7 @@ def run(args):
 
     where_str, where_dict = pdk_db.where_dict(l)
 
-    sql = "select distinct project, host, context, test_name from result_scalar %s " % where_str
+    sql = "select distinct project, host, context, test_name, test_hash from result_scalar %s " % where_str
     c = pdk_db.execute(sql, where_dict)
 
     for (project, host, context, test_name) in c:
@@ -84,12 +84,13 @@ def run(args):
         # ok.
         try:
             pdk_db.execute(
-                'insert into expected ( test_run_type, project, host, context, test_name ) values ( :1, :2, :3, :4, :5 )',
+                'insert into expected ( test_run_type, project, host, context, test_name, test_hash ) values ( :1, :2, :3, :4, :5, :6 )',
                 (test_run_type,
                  project,
                  host,
                  context,
-                 test_name))
+                 test_name,
+                 test_hash))
         except pdk_db.IntegrityError as e:
             if debug:
                 print("exception %s" % e)

--- a/pandokia/sql/mysql.sql
+++ b/pandokia/sql/mysql.sql
@@ -84,8 +84,8 @@ CREATE TABLE result_scalar (
                 -- 0 or 1 indicating whether this test is a chronic problem
 	);
 
-CREATE UNIQUE INDEX result_scalar_test_identity 
-	ON result_scalar ( test_run, project, host, test_name, context );
+CREATE UNIQUE INDEX result_scalar_key_id 
+	ON result_scalar ( key_id );
 
 CREATE INDEX result_scalar_test_run_only 
 	ON result_scalar ( test_run ) ;

--- a/pandokia/sql/sqlite.sql
+++ b/pandokia/sql/sqlite.sql
@@ -69,8 +69,8 @@ CREATE TABLE result_scalar (
 		-- 0 or 1 indicating whether this test is a chronic problem
 );
 
-CREATE UNIQUE INDEX result_scalar_test_identity
-	ON result_scalar ( test_run, project, host, test_name, context );
+CREATE UNIQUE INDEX result_scalar_key_id
+	ON result_scalar ( key_id );
 
 CREATE INDEX result_scalar_test_run_only
 	ON result_scalar ( test_run ) ;


### PR DESCRIPTION
Refer to the problem Christine described in [pervious PR](https://github.com/spacetelescope/pandokia/pull/28#issue-208110021), we need to shorten the unique index in result_scalar table since it will exceed the limit of InnoDB in some test cases.
Therefore, I would like to change the unique index to `key_id`, which is an auto-incremating field.