### PR TITLE
Make bare minimum Py3-compatibility changes needed for JETC py3 runs

### DIFF
--- a/pandokia/check_expected.py
+++ b/pandokia/check_expected.py
@@ -1,6 +1,6 @@
 #
 # pandokia - a test reporting and execution system
-# Copyright 2009, 2011, Association of Universities for Research in Astronomy (AURA) 
+# Copyright 2009, 2011, Association of Universities for Research in Astronomy (AURA)
 #
 #
 # check_expected - check that expected tests exist in a test run
@@ -8,16 +8,16 @@
 
 ##80############################################################################
 '''
-pdk check_expected [ -p project ] [ -h host ] 
+pdk check_expected [ -p project ] [ -h host ]
     [ -c context ] [ -m custom ] test_run_type test_run_to_check
 
-    check that all expected tests from test_run_type are present 
+    check that all expected tests from test_run_type are present
     in test_run_to_check
 
     -p pname
     --project pname
         check only expectations for project pname
-        
+
     -h hname
     --host hname
         check only expectations for host hname
@@ -61,7 +61,7 @@ import pandokia.helpers.easyargs as easyargs
 def run(args) :
 
     spec = {
-        '-v'  : '', 
+        '-v'  : '',
         '-h'  : '=+',
         '-p'  : '=+',
         '-c'  : '=+',
@@ -80,7 +80,7 @@ def run(args) :
     opt, args = easyargs.get( spec, args )
 
     if opt['--help'] :
-        print __doc__
+        print(__doc__)
         return
 
     verbose = opt['-v']
@@ -89,17 +89,17 @@ def run(args) :
         test_run_type = args[0]
         test_run = args[1]
     except :
-        print "\ncan't get args, try:\n    pdk check_expected --help\n"
+        print("\ncan't get args, try:\n    pdk check_expected --help\n")
         return 1
 
     # normalize the test run, so they can say stuff like "daily_latest"
     test_run = common.find_test_run( test_run )
 
-    print "TYPE ",test_run_type
-    print "test_run",test_run
+    print("TYPE %s" % test_run_type)
+    print("test_run %s" % test_run)
 
     if test_run.endswith('latest') :
-        print "this test run name is probably a mistake"
+        print("this test run name is probably a mistake")
         return 1
 
     # construct the query for the set of tests that we are expecting
@@ -120,15 +120,15 @@ def run(args) :
     s = "SELECT project, host, test_name, context, custom FROM expected %s " % where_text
 
     if verbose > 1 :
-        print s
-        print where_dict
+        print(s)
+        print(where_dict)
 
     # perform the query
 
     c = pdk_db.execute( s, where_dict )
 
     if verbose > 1 :
-        print "query done"
+        print("query done")
 
     # check each test reported in the query result
 
@@ -136,23 +136,23 @@ def run(args) :
 
     for ( project, host, test_name, context, custom ) in c :
         if verbose > 2 :
-            print "CHECK",project, host, test_name
+            print("CHECK %s %s %s" % (project, host, test_name))
 
-        c1 = pdk_db.execute("""SELECT status FROM result_scalar 
-                WHERE test_run = :1 AND project = :2 AND host = :3 AND 
-                test_name = :4 AND context = :5 AND custom = :6""", 
-                ( test_run, project, host, test_name, context, custom ) 
+        c1 = pdk_db.execute("""SELECT status FROM result_scalar
+                WHERE test_run = :1 AND project = :2 AND host = :3 AND
+                test_name = :4 AND context = :5 AND custom = :6""",
+                ( test_run, project, host, test_name, context, custom )
             )
-	a = c1.fetchone()
+        a = c1.fetchone()
         if a is None:
             # it wasn't there
             if verbose :
-                print "        MISSING:", project, host, test_name
+                print("        MISSING: %s %s %s" % (project, host, test_name))
 
-            pdk_db.execute("""INSERT INTO result_scalar 
-                ( test_run, project, host, context, custom, test_name, status, attn ) 
+            pdk_db.execute("""INSERT INTO result_scalar
+                ( test_run, project, host, context, custom, test_name, status, attn )
                 VALUES ( :1, :2, :3, :4, :5, :6, :7, :8 )""",
-                 ( test_run, project, host, context, custom, test_name, 'M', 'Y' ) 
+                 ( test_run, project, host, context, custom, test_name, 'M', 'Y' )
                 )
             detected = detected + 1
 
@@ -165,4 +165,4 @@ def run(args) :
     pdk_db.commit()
 
 
-    print "detected ",detected
+    print("detected %s" % detected)

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -14,16 +14,9 @@ import os.path
 import re
 import types
 
-try:
-    import cStringIO
-except ImportError:
-    from io import StringIO as cStringIO
-
-try:
-    from urllib.parse import quote_plus, urlencode
-except ImportError:
-    from urllib import urlencode, quote_plus
-
+from six import StringIO
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.parse import quote_plus
 
 import pandokia
 cfg = pandokia.cfg
@@ -347,7 +340,7 @@ var_pattern = re.compile("(%[^;]*);")
 
 
 def expand(text, dictlist=[], valid=None, format=''):
-    result = cStringIO.StringIO()
+    result = StringIO()
     textlist = re.split(var_pattern, text)
     for x in textlist:
         if x.startswith('%'):

--- a/pandokia/gen_expected.py
+++ b/pandokia/gen_expected.py
@@ -1,6 +1,6 @@
 #
 # pandokia - a test reporting and execution system
-# Copyright 2009, Association of Universities for Research in Astronomy (AURA) 
+# Copyright 2009, Association of Universities for Research in Astronomy (AURA)
 #
 
 #
@@ -15,6 +15,7 @@
 #       fills in missing tests in test_run_to_check
 #
 #
+from __future__ import print_function
 
 debug = 0
 
@@ -34,20 +35,20 @@ def run(args) :
         '--context' : '-c',
         '--project' : '-p',
         '--host'    : '-h',
-	'--custom' : '-m',
+        '--custom' : '-m',
          }, args )
 
     try :
         test_run_type = args[0]
         test_run_pattern = args[1]
     except :
-        print "can't get args"
-        print "   pdk gen_expected test_run_type test_run_pattern"
+        print("can't get args")
+        print("   pdk gen_expected test_run_type test_run_pattern")
         sys.exit(1)
 
     test_run_pattern = common.find_test_run( test_run_pattern )
 
-    print "test_run_pattern = ",test_run_pattern
+    print("test_run_pattern = ",test_run_pattern)
 
     l = [ ('test_run', test_run_pattern ) ]
 
@@ -63,8 +64,8 @@ def run(args) :
 
     if debug :
         for x in l :
-            print "	",x
-        print "?"
+            print("	",x)
+        print("?")
         sys.stdin.readline()
 
     where_str, where_dict = pdk_db.where_dict( l )
@@ -74,20 +75,20 @@ def run(args) :
 
     for ( project, host, context, custom, test_name ) in c :
         if test_name.endswith("nose.failure.Failure.runTest") :
-            # Sometimes nose generates this test name.  I don't want it in the database at all, because 
+            # Sometimes nose generates this test name.  I don't want it in the database at all, because
             # the name is not unique, and the record does not contain any useful information about the problem.
             # In any case, we never want to list this test as "expected", even if it leaks into the database.
             continue
 
         if debug :
-            print "expect ",test_run_type, project, host, context, custom, test_name
-	a = pdk_db.execute('select * from expected where test_run_type = :1 and project = :2 and host = :3 and context = :4 and custom = :5 and test_name = :6', (test_run_type, project, host, context, custom, test_name))
+            print("expect ",test_run_type, project, host, context, custom, test_name)
+        a = pdk_db.execute('select * from expected where test_run_type = :1 and project = :2 and host = :3 and context = :4 and custom = :5 and test_name = :6', (test_run_type, project, host, context, custom, test_name))
         y = a.fetchone()
         if y is None:
-            try : 
+            try :
                 pdk_db.execute('insert into expected ( test_run_type, project, host, context, custom, test_name ) values ( :1, :2, :3, :4, :5, :6 )', ( test_run_type, project, host, context, custom, test_name ))
             except Exception, e:
                 if debug :
-                    print "exception", e
+                    print("exception", e)
                 pass
     pdk_db.commit()


### PR DESCRIPTION
Requesting Oi In's review.  Happy to get @cslocum 's / @jhunkeler 's / @vglaidler's as well, but plan to merge even if only Oi In okays it.  The current pandokia brokenness is apparently blocking normal Py3 test runs right now (stuff fails during init due to this, so even if the tests do seem to run, stuff is wrong).

This test run log:
- http://plglitch.stsci.edu:8080/jwst/test/reports/logs/pandeia_cp_of_master_2018-12-21-09:39:17.main

shows that the version of pandokia in github if NOT YET FULLY Python3 compliant.  This PR fixes those issues.

This PR is INTENTIONALLY not attempting to fix all such issues.  I picked the few files involved (and one they all use: common.py) and upgraded them by fixing bad `print` and `StringIO` and `urllib` usages.  The resulting code targets both py2 and py3.

We should some day make a larger pass through all the code doing 2 things:
- making it ALL py compliant
- seeing which files are no longer used

but I am intentionally not doing that right now (less code changed = less to test = less risk).