### PR TITLE
also fix the old style exception catching syntax

### DIFF
--- a/pandokia/gen_expected.py
+++ b/pandokia/gen_expected.py
@@ -87,7 +87,7 @@ def run(args) :
         if y is None:
             try :
                 pdk_db.execute('insert into expected ( test_run_type, project, host, context, custom, test_name ) values ( :1, :2, :3, :4, :5, :6 )', ( test_run_type, project, host, context, custom, test_name ))
-            except Exception, e:
+            except Exception as e:
                 if debug :
                     print("exception", e)
                 pass

--- a/pandokia/import_data.py
+++ b/pandokia/import_data.py
@@ -225,7 +225,7 @@ class test_result(object):
 
     def try_insert(self, db, key_id) :
 
-    global reimport_count, reimport_parm
+        global reimport_count, reimport_parm
 
         if self.has_okfile :
             okf = 'T'
@@ -302,7 +302,7 @@ class test_result(object):
 
             assert key_id is not None, 'ERROR: key_id should not be None!'
 
-        except db.IntegrityError, e:
+        except db.IntegrityError as e:
             print('ERROR: we hit an integrity error in import_data.py! (key_id = %s)' %str(key_id))
             db.rollback()
             # if it is already there, look it up - if it is status 'M' then we are just now receiving
@@ -450,7 +450,7 @@ def run(args, hack_callback = None) :
                     x["project"] = default_project
                 if not "test_runner" in x :
                     x["test_runner"] = default_test_runner
-            except Exception, e:
+            except Exception as e:
                 print(e, line_count)
                 continue
 


### PR DESCRIPTION
Also fix the old style exception catching syntax.

And fix an incorrect indent during a whitespace change in the last PR, #36.

See syntax errors in this Py3 run log:
- http://plglitch.stsci.edu:8080/jwst/test/reports/logs/pandeia_cp_of_master_2018-12-21-15:36:38.main