### PR TITLE
Set pdk_updates based on an env variable

### DIFF
--- a/pandokia/ok.py
+++ b/pandokia/ok.py
@@ -32,7 +32,7 @@ except AttributeError:
 
 old = '.%s.old' % datetime.date.today().isoformat()
 
-pdk_updates = '/eng/ssb/tests/pdk_updates/'
+pdk_updates = os.environ.get('PDK_UPDATES', '/eng/etc/test/pdk_updates')
 old_pdk_updates = os.path.join(pdk_updates, 'old')
 if not os.path.exists(old_pdk_updates):
     try:


### PR DESCRIPTION
`pdk ok` will now look for *.ok files in a directory set by $PDK_UPDATES.  If that variable is not defined, it defaults to /eng/etc/test/pdk_updates.