### PR TITLE
Handle SSO authentication

### DIFF
--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -36,32 +36,18 @@ def check_auth():
     # Assume they are not authorized, then look for a reason to allow them in.
     auth_ok = 0
 
-    # If the web server checked them with BasicAuth, we will use that:
-
-    if ("AUTH_TYPE" in os.environ) and (os.environ["AUTH_TYPE"] == 'Basic'):
-        if cfg.user_list is None:
-            # If there is no user_list in the config, any authenticated user is
-            # accepted.
-            auth_ok = 1
-        else:
-            # If the config contains user_list, only those people are
-            # authorized.
-            if os.environ["REMOTE_USER"] in cfg.user_list:
-                auth_ok = 1
-
-        # One way or another, we have an answer now
-        return auth_ok
-
-    # The web server is not enforcing authentication.
-
     if cfg.user_list is None:
-        # we don't have a list to restrict to, so anybody is ok
+        # If there is no user_list in the config, any authenticated user is
+        # accepted.
         auth_ok = 1
-    else:
-        # we have a list of users, but we don't know who this one is
-        auth_ok = 0
+
+    user = current_user()
+    if user in cfg.user_list:
+        # If the config contains user_list, only those people are authorized.
+        auth_ok = 1
 
     return auth_ok
+
 
 #
 # function to create a URL for a link back to our own CGI
@@ -417,11 +403,12 @@ cgi_header_html = "content-type: text/html\n\n"
 
 current_user_name = None
 
-
 def current_user():
-    if 'REMOTE_USER' in os.environ:
-        return os.environ["REMOTE_USER"]
-    return 'Nobody'
+    eppn = os.getenv('HTTP_EPPN')
+    if eppn:
+        return eppn.replace('@stsci.edu', '')
+    else:
+        return 'Nobody'
 
 ######
 #--#--# GENERAL

--- a/pandokia/pcgi.py
+++ b/pandokia/pcgi.py
@@ -114,6 +114,9 @@ def run():
         f = open(f, "r")
         x = f.read()
         f.close()
+
+	user = common.current_user()
+
         if common.current_user() in common.cfg.admin_user_list:
             x = re.sub(
                 "ADMINLINK",
@@ -121,8 +124,11 @@ def run():
                 x)
         else:
             x = re.sub("ADMINLINK", '', x)
+
+        x = re.sub("CURRENTUSER", user, x)
         x = re.sub("CGINAME", cginame, x)
         x = re.sub("PAGEHEADER", header, x)
+
         sys.stdout.write(x)
         sys.exit(0)
 

--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -6,6 +6,12 @@ Documentation is available on the group wiki:
 https://svn.stsci.edu/trac/ssb/development/wiki/Pandokia
 </a>
 
+<br/><br/>
+
+Logged in as: <b>CURRENTUSER</b>
+
+<br/>
+
 ADMINLINK
 
 <p>


### PR DESCRIPTION
Now that we have the glitch proxy in place and are requiring authentication via SSO, we need to

1) add a whitelist of users who have access to Pandokia (otherwise, anyone with a MyST account could view our stuff)

2) get the application to know who is logged in by parsing header information from the SSO redirect

For convenience, I also added a "Logged in as" line to the front page.