### PR TITLE
fix bug I introduced - debug_fd does not exist unless debug=True

### DIFF
--- a/pandokia/helpers/runner_minipyt.py
+++ b/pandokia/helpers/runner_minipyt.py
@@ -385,7 +385,8 @@ def run_test_class_single(rpt, mod, name, ob, test_order):
         class_ob = ob()
     except:
         exception_str = get_exception_str()
-        debug_fd.write('bailing out early trying to instantiate class %s, named %s, for: %s\n' % (ob, name, exception_str))
+        if debug:
+            debug_fd.write('bailing out early trying to instantiate class %s, named %s, for: %s\n' % (ob, name, exception_str))
         traceback.print_exc()
         # really nothing more we can do...
         gen_report(rpt, name, 'E', class_start_time, time.time(), {}, {


### PR DESCRIPTION
I introduced this bug in #55 where I added a debug line.  I am SOO sorry...   :-)

I noticed this issue in this test run:
- https://glitch.etc.stsci.edu/pandokia.cgi?query=detail&key_id=202566480

where this happens:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data1/miniconda3/envs/pyetc_tp22dev1_linux_py36/lib/python3.6/site-packages/pandokia/helpers/runner_minipyt.py", line 736, in process_file
    run_test_class(rpt, module, name, ob, test_order)
  File "/data1/miniconda3/envs/pyetc_tp22dev1_linux_py36/lib/python3.6/site-packages/pandokia/helpers/runner_minipyt.py", line 568, in run_test_class
    run_test_class_single(rpt, mod, name, ob, test_order)
  File "/data1/miniconda3/envs/pyetc_tp22dev1_linux_py36/lib/python3.6/site-packages/pandokia/helpers/runner_minipyt.py", line 388, in run_test_class_single
    debug_fd.write('bailing out early trying to instantiate class %s, named %s, for: %s\n' % (ob, name, exception_str))
NameError: name 'debug_fd' is not defined
```