### PR TITLE
rm link for LOCAL JETC tests; add link for glitch JETC runs from log level

### DIFF
--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -64,7 +64,7 @@ https://svn.stsci.edu/trac/ssb/development/wiki/Pandokia
 
 <a href="CGINAME?query=expected">Expected tests summary</a>
 <p>
-<a href="https://glitch.etc.stsci.edu/jwst/test/reports">JWST ETC test reports (includes log files)</a>
+<a href="https://glitch.etc.stsci.edu/jwst/test/reports">JWST ETC test meta-reports (run log files)</a>
 
 <hr>
 <br/>

--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -20,7 +20,7 @@ https://svn.stsci.edu/trac/ssb/development/wiki/Pandokia
 <!--<li> <a href="CGINAME?query=day_report.2&test_run=jwst_latest">Latest JWST Report</a>-->
 
 <li> <a href="CGINAME?query=day_report.2&test_run=etc_hst_daily_latest"><b>Latest HST pyetc</b></a>
-<li> <a href="CGINAME?query=day_report.2&test_run=etc_jwst_daily_latest"><b>Latest Pandeia Report (Local)</b></a>
+<!-- <li> <a href="CGINAME?query=day_report.2&test_run=etc_jwst_daily_latest"><b>Latest Pandeia Report (Local)</b></a> -->
 <li> <a href="CGINAME?query=day_report.2&test_run=pandeia_master_latest"><b>Latest Pandeia Report (AWS)</b></a>
 
 <br/>
@@ -63,6 +63,8 @@ https://svn.stsci.edu/trac/ssb/development/wiki/Pandokia
 <br/>
 
 <a href="CGINAME?query=expected">Expected tests summary</a>
+<p>
+<a href="https://glitch.etc.stsci.edu/jwst/test/reports">JWST ETC test reports (includes log files)</a>
 
 <hr>
 <br/>


### PR DESCRIPTION
Remove an unused link and add a new useful link, both affecting JETC.

Tried this locally and the page looks right and links work.

Not asking for this to get into a TP or anything, but when this is merged I can pull it into the repo used on glitch to publish the changes.  I think.