### PR TITLE
found old has_key() usages to fix for py3

### DIFF
--- a/pandokia/import_data.py
+++ b/pandokia/import_data.py
@@ -150,7 +150,7 @@ all_test_runs = { }
 class test_result(object):
 
     def _lookup(self,name,default=None) :
-        if self.dict.has_key(name) :
+        if name in self.dict:
             return self.dict[name]
         if default != None :
             return default

--- a/stsci_regtest/pdkregress.py
+++ b/stsci_regtest/pdkregress.py
@@ -310,7 +310,7 @@ class Regress:
                         repr(err), config["title"])
                     crash = 1
 
-            # end: if config.has_key("taskname") and config['taskname'].strip()
+            # end: if "taskname" in config and config['taskname'].strip()
             # != '' :
 
             # Run any post-execution commands in the configuration file


### PR DESCRIPTION
The first one bit Oi In today during a pdk import.  The second one is just a comment in an unused test script (which imports pyraf!!  wow).

@vglaidler it would be lovely if you would double-check my work, but I am going to merge now to get glitch back on track.  glitch uses master, so we don't need to update our TP's with this fix in any kind of hurry.  Next TP version will grab it.