### PR TITLE
Fixing python 3 deprecation warnings in our code base

### DIFF
--- a/pandokia/db.py
+++ b/pandokia/db.py
@@ -16,7 +16,7 @@ re_funky_chars = re.compile('[^ -~]')
 # Yes, it works on strings with \0 in them.
 # Should we do iso-8859 or just wait to support unicode?
 
-re_star_x_star = re.compile('^\*[^*]*\*$')
+re_star_x_star = re.compile(r'^\*[^*]*\*$')
 
 
 class name_sequence(object):

--- a/pandokia/db_psycopg2.py
+++ b/pandokia/db_psycopg2.py
@@ -168,7 +168,7 @@ Ubuntu:
     su postgres
 
     psql postgres
-        /password postgres
+        \\password postgres
         ...enter a password...
             sets password for postgres database user
 

--- a/pandokia/db_psycopg2.py
+++ b/pandokia/db_psycopg2.py
@@ -203,7 +203,7 @@ Fedora:
     su postgres
 
     psql postgres
-        /password postgres
+        \\password postgres
         ...enter a password...
             sets password for postgres database user
 
@@ -233,12 +233,12 @@ psql pandokia
 
 
 psql
-    /d
+    \\d
         like show tables
-    /l
+    \\l
         like show databases
-    /d tablename
+    \\d tablename
         like describe tablename
-    /connect name
+    \\connect name
         like "use name"
 """

--- a/pandokia/db_psycopg2.py
+++ b/pandokia/db_psycopg2.py
@@ -153,7 +153,7 @@ class PandokiaDB(pandokia.db.where_dict_base):
         return c.fetchone()[0]
 
 
-'''
+"""
 Ubuntu:
 
     sudo apt-get install postgresql-client
@@ -243,4 +243,4 @@ psql
         like "use name"
 
 
-'''
+"""

--- a/pandokia/db_psycopg2.py
+++ b/pandokia/db_psycopg2.py
@@ -168,7 +168,7 @@ Ubuntu:
     su postgres
 
     psql postgres
-        \password postgres
+        /password postgres
         ...enter a password...
             sets password for postgres database user
 
@@ -203,7 +203,7 @@ Fedora:
     su postgres
 
     psql postgres
-        \password postgres
+        /password postgres
         ...enter a password...
             sets password for postgres database user
 
@@ -233,14 +233,12 @@ psql pandokia
 
 
 psql
-    \d
+    /d
         like show tables
-    \l
+    /l
         like show databases
-    \d tablename
+    /d tablename
         like describe tablename
-    \connect name
+    /connect name
         like "use name"
-
-
 """

--- a/pandokia/envgetter.py
+++ b/pandokia/envgetter.py
@@ -53,7 +53,7 @@ ttop = 'pandokia_top'
 
 # Patterns pertinent to substitutions:
 
-pat = {'envpat': re.compile('\${?([\w]*?)}?(?:[\\/:]|$)'),
+pat = {'envpat': re.compile(r'\${?([\w]*?)}?(?:[\\/:]|$)'),
        # Matches an environment variable that
        # starts with a $
        # optionally followed by a {
@@ -63,11 +63,11 @@ pat = {'envpat': re.compile('\${?([\w]*?)}?(?:[\\/:]|$)'),
        #    or the end of the string
        # Only the name of the environment variable will be taken.
 
-       'pathkey': re.compile('[\w]*path$', re.I),
+       'pathkey': re.compile(r'[\w]*path$', re.I),
        # Anything that ends in path, case-insensitive. Used to match
        # something that was extracted as above.
 
-       'pathval': re.compile('(\$\{?[\w]*path\}?)(?:[/:]|$)', re.I)}
+       'pathval': re.compile(r'(\$\{?[\w]*path\}?)(?:[/:]|$)', re.I)}
 # Matches an environment variable that
 # starts with a $
 # optionally followed by a {

--- a/pandokia/helpers/dict_comp.py
+++ b/pandokia/helpers/dict_comp.py
@@ -153,7 +153,7 @@ def read_reference(fn):
 ##########
 
 
-spaces = re.compile("[\s]")
+spaces = re.compile(r"[\s]")
 
 ##########
 #

--- a/pandokia/helpers/nose_plugin.py
+++ b/pandokia/helpers/nose_plugin.py
@@ -51,7 +51,7 @@ def pdktimestamp(tt):
 def cleanname(name):
     """Removes any object id strings from the test name. These
     can occur in the case of a generated test."""
-    pat = re.compile(".at.0x\w*>")
+    pat = re.compile(r".at.0x\w*>")
     newname = re.sub(pat, '>', name)
     return newname
 

--- a/pandokia/helpers/pytest_plugin.py
+++ b/pandokia/helpers/pytest_plugin.py
@@ -69,7 +69,7 @@ def pdktimestamp(tt):
 def cleanname(name):
     """Removes any object id strings from the test name. These
     can occur in the case of a generated test."""
-    pat = re.compile(".at.0x\w*>")
+    pat = re.compile(r".at.0x\w*>")
     newname = re.sub(pat, '>', name)
     return newname
 

--- a/pandokia/runners/maker.py
+++ b/pandokia/runners/maker.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     # group 0 is the tag that comes before the command
     #   $ > >>>
     # group 1 is the actual tag
-    command_re = re.compile('[^ \t]{0,5}[ \t]*([>\$]+)[ \t]*(.*$)')
+    command_re = re.compile(r'[^ \t]{0,5}[ \t]*([>\$]+)[ \t]*(.*$)')
 
     #
     windows = platform.system() == 'Windows'

--- a/pandokia/text_table.py
+++ b/pandokia/text_table.py
@@ -9,7 +9,7 @@
 
 __all__ = ["text_table"]
 
-import cgi
+import html
 import csv
 import sys
 
@@ -517,7 +517,7 @@ class text_table:
                     s.write(self.title_html[colcount])
                 elif self.title_links[colcount]:
                     s.write("<a href='" + self.title_links[colcount] + "'>")
-                    s.write(cgi.escape(str(r)))
+                    s.write(html.escape(str(r)))
                     s.write("</a>")
                 else:
                     s.write(r)
@@ -565,7 +565,7 @@ class text_table:
                         if c.text is not None and c.code:
                             s.write("<pre>{}</pre>".format(c.text))
                         elif c.text is not None and not c.code:
-                            s.write(cgi.escape(str(c.text)))
+                            s.write(html.escape(str(c.text)))
                         else:
                             s.write("&nbsp;")
                     if c.link:

--- a/stsci_regtest/comparison.py
+++ b/stsci_regtest/comparison.py
@@ -185,7 +185,7 @@ class AsciiComparison(ComparisonClass):
        <ignore_wstart> nref, mtab </ignore_wstart>
        <ignore_wend> .fits, .dat </ignore_wend>
        <ignore_regexp> r'\sbla.*' </ignore_regexp>
-       """
+    """
 
     def __init__(self, testfile, reffile, **kwds):
         ComparisonClass.__init__(self, testfile, reffile)

--- a/stsci_regtest/comparison.py
+++ b/stsci_regtest/comparison.py
@@ -179,7 +179,7 @@ class FitsComparison(ComparisonClass):
 
 
 class AsciiComparison(ComparisonClass):
-    """Override methods for Ascii Comparison. Ignore keywords include:
+    """ Override methods for Ascii Comparison. Ignore keywords include:
 
        <ignore_date> True </ignore_date>
        <ignore_wstart> nref, mtab </ignore_wstart>

--- a/stsci_regtest/comparison.py
+++ b/stsci_regtest/comparison.py
@@ -184,7 +184,7 @@ class AsciiComparison(ComparisonClass):
        <ignore_date> True </ignore_date>
        <ignore_wstart> nref, mtab </ignore_wstart>
        <ignore_wend> .fits, .dat </ignore_wend>
-       <ignore_regexp> r'\sbla.*' </ignore_regexp>
+       <ignore_regexp> r'\\sbla.*' </ignore_regexp>
     """
 
     def __init__(self, testfile, reffile, **kwds):


### PR DESCRIPTION
This PR includes any **deprecation warning fixes**:
  - for invalid escape sequence: use either raw string literals or double backslashes in regular expressions
  - for cgi.escape is deprecated: use html.escape instead
     for difference between cgi.escape and html.escape: https://wiki.python.org/moin/EscapingHtml

Other details in sister PR: https://github.com/spacetelescope/pandeia/pull/4923