### PR TITLE
Second round of fixing deprecation warning in our repos

### DIFF
--- a/pandokia/envgetter.py
+++ b/pandokia/envgetter.py
@@ -358,7 +358,7 @@ class EnvGetter(object):
 def parsefile(fname, platform=''):
     """Helper function: Make a configparser, parse the file,
     return the dictionary."""
-    cfg = configparser.SafeConfigParser()
+    cfg = configparser.ConfigParser()
     cfg.optionxform = str  # retain case sensitivity!!
     cfg.read(fname)
     ans = {}


### PR DESCRIPTION
(sorry I missed some during the first round)
This PR includes any **deprecation warning fixes**:
  - using ConfigParser instead of SafeConfigParser (and [confirmed](https://docs.python.org/3/library/configparser.html) that they both have the same functionalities the envgetter script uses)
 - (waiting for env_platforms decision)

Test run link:
https://glitch.etc.stsci.edu/pandokia.cgi?query=day_report.2&test_run=user_pandeia_oitl_DeprecationWarning_JETC-938_2020-04-01-16:31:30
(Final - chronic known issue websocket close error
Client - osx upload page known issue
linux workbook server error test fail due to 'Could not load driver for firefox', but osx version passed)

Sister PRs (other details in Pandeia PR):
https://github.com/spacetelescope/pandeia/pull/4931
https://github.com/spacetelescope/pandeia_test/pull/986
https://github.com/spacetelescope/pandeia/pull/4931