### PR TITLE
Use platform.release instead of platform.dist in env_platfroms.py

### DIFF
--- a/pandokia/env_platforms.py
+++ b/pandokia/env_platforms.py
@@ -5,9 +5,14 @@ the appoprirate specific subsections of the pdk_environment files.
 
 By its nature, this information is expected to be site-specific.
 Users may need or wish to tailor it for their specific test situation."""
-
-import platform
-
+#############################################################
+# import platform
+# Platform package has been deprecated, and there is no clean
+# drop-in replacement.
+# Since we're not presently using platform sections in any
+# pdk_environment files, we're just going to break it with
+# a helpful exception. See additional comments inline.
+#############################################################
 # Hierarchy: this is an ordered list that specifies the order
 # in which the subsections will be applied
 hierarchy = ['os',
@@ -22,13 +27,22 @@ cpudict = dict(i386='x86',
                i686='x86')
 
 
-class PlatformType(object):
+class 
+
+
+
+
+Type(object):
     """Base class from which specific sub-classes that need special
     handling can be instantiated."""
 
     def __init__(self):
         """Constructor takes no arguments because it will call platform
         routines."""
+        
+        raise NotImplementedError("Platform-specific environment handling is not currently supported. Modify env_platforms.py to fix.")
+        
+   
         # Items we use directly
         self.os = platform.system().lower()
         self.osver = None

--- a/pandokia/env_platforms.py
+++ b/pandokia/env_platforms.py
@@ -5,6 +5,9 @@ the appoprirate specific subsections of the pdk_environment files.
 
 By its nature, this information is expected to be site-specific.
 Users may need or wish to tailor it for their specific test situation."""
+
+import platform
+
 # Hierarchy: this is an ordered list that specifies the order
 # in which the subsections will be applied
 hierarchy = ['os',

--- a/pandokia/env_platforms.py
+++ b/pandokia/env_platforms.py
@@ -5,14 +5,6 @@ the appoprirate specific subsections of the pdk_environment files.
 
 By its nature, this information is expected to be site-specific.
 Users may need or wish to tailor it for their specific test situation."""
-#############################################################
-# import platform
-# Platform package has been deprecated, and there is no clean
-# drop-in replacement.
-# Since we're not presently using platform sections in any
-# pdk_environment files, we're just going to break it with
-# a helpful exception. See additional comments inline.
-#############################################################
 # Hierarchy: this is an ordered list that specifies the order
 # in which the subsections will be applied
 hierarchy = ['os',
@@ -27,21 +19,13 @@ cpudict = dict(i386='x86',
                i686='x86')
 
 
-class 
-
-
-
-
-Type(object):
+class PlatformType(object):
     """Base class from which specific sub-classes that need special
     handling can be instantiated."""
 
     def __init__(self):
         """Constructor takes no arguments because it will call platform
         routines."""
-        
-        raise NotImplementedError("Platform-specific environment handling is not currently supported. Modify env_platforms.py to fix.")
-        
    
         # Items we use directly
         self.os = platform.system().lower()

--- a/pandokia/env_platforms.py
+++ b/pandokia/env_platforms.py
@@ -52,7 +52,6 @@ Type(object):
         # Items that will be used to construct the rest
         self.processor = platform.processor().lower()
         self.uname = [x.lower() for x in platform.uname()]
-        self.dist = [x.lower() for x in platform.dist()]
         self.arch = platform.architecture()[0].lower()
 
         # Construct the cpu
@@ -70,8 +69,8 @@ Type(object):
     def makeosver(self):
         if self.os in ['linux']:
             # Toss subrelease
-            ver = self.dist[1].split('.')[0]
-            self.osver = ''.join([self.dist[0], ver])
+            ver = platform.release().split('.')[0]
+            self.osver = ''.join([self.os, ver])
 
         if self.os in ['darwin']:
             # Toss subrelease

--- a/pandokia/envgetter.py
+++ b/pandokia/envgetter.py
@@ -303,7 +303,7 @@ class EnvGetter(object):
         self.context = context  # contexts modify default environment
 
         # Platform info
-        self.platform = None
+        self.platform = PlatformType()
 
         # for testing purposes
         self.MOCK = mock

--- a/pandokia/envgetter.py
+++ b/pandokia/envgetter.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
     import configparser
 
-
+from pandokia.env_platforms import PlatformType
 import pandokia.common as common
 
 # Common variables used by both classes:

--- a/pandokia/envgetter.py
+++ b/pandokia/envgetter.py
@@ -39,14 +39,6 @@ try:
 except ImportError:
     import configparser
 
-#############################################
-# The platform module has been deprecated. Since we
-# don't currently use it in any of our pdk_environment files,
-# we are commenting out & will raise a helpful exception
-# if anyone tries to use it.
-#
-# from pandokia.env_platforms import PlatformType
-#############################################
 
 import pandokia.common as common
 
@@ -310,12 +302,7 @@ class EnvGetter(object):
         self.nodes = dict()  # dictionary of DirLevel objects
         self.context = context  # contexts modify default environment
 
-        #####################################################
-        # This functionality is not presently supported.
-        #
         # Platform info
-        # self.platform = PlatformType()
-        #####################################################
         self.platform = None
 
         # for testing purposes

--- a/pandokia/envgetter.py
+++ b/pandokia/envgetter.py
@@ -40,6 +40,7 @@ except ImportError:
     import configparser
 
 from pandokia.env_platforms import PlatformType
+
 import pandokia.common as common
 
 # Common variables used by both classes:

--- a/pandokia/envgetter.py
+++ b/pandokia/envgetter.py
@@ -39,7 +39,14 @@ try:
 except ImportError:
     import configparser
 
-from pandokia.env_platforms import PlatformType
+#############################################
+# The platform module has been deprecated. Since we
+# don't currently use it in any of our pdk_environment files,
+# we are commenting out & will raise a helpful exception
+# if anyone tries to use it.
+#
+# from pandokia.env_platforms import PlatformType
+#############################################
 
 import pandokia.common as common
 
@@ -303,8 +310,13 @@ class EnvGetter(object):
         self.nodes = dict()  # dictionary of DirLevel objects
         self.context = context  # contexts modify default environment
 
+        #####################################################
+        # This functionality is not presently supported.
+        #
         # Platform info
-        self.platform = PlatformType()
+        # self.platform = PlatformType()
+        #####################################################
+        self.platform = None
 
         # for testing purposes
         self.MOCK = mock


### PR DESCRIPTION
This will break Pandokia functionality that we are not currently using. Raise an exception with a helpful hint in case anyone does try to use it.

(Argh, simple approach is insufficient. WIP.)