### PR TITLE
Fixing no html module in python 2 issue

### DIFF
--- a/pandokia/text_table.py
+++ b/pandokia/text_table.py
@@ -9,7 +9,11 @@
 
 __all__ = ["text_table"]
 
-import html
+try:
+    import cgi as html
+except ImportError:
+    import html
+
 import csv
 import sys
 


### PR DESCRIPTION
Details in https://github.com/spacetelescope/pandokia/pull/64#issuecomment-612032707

Installing Pandokia in python 2:
(Before)
<img width="917" alt="Screen Shot 2020-04-10 at 1 29 30 PM" src="https://user-images.githubusercontent.com/17505249/79010250-99121580-7b2f-11ea-8abd-047ff3268507.png">

(After)
<img width="921" alt="Screen Shot 2020-04-10 at 1 31 49 PM" src="https://user-images.githubusercontent.com/17505249/79010275-aaf3b880-7b2f-11ea-9f48-7a10ac4fc1b0.png">

Pandeia test run:
(Sanity check) https://glitch.etc.stsci.edu/jwst/test/reports/user_pandeia_oitl_fix_for_python2_2020-04-10-13:33:10.html