### PR TITLE
Fixing python 3 warnings in repos

### DIFF
--- a/pandokia/helpers/runner_minipyt.py
+++ b/pandokia/helpers/runner_minipyt.py
@@ -11,9 +11,9 @@ import gc
 import copy
 
 try:
-    import collections
-except ImportError:
     import collections.abc as collections
+except ImportError:
+    import collections
 
 # In python 2.6 and later, this prevents writing the .pyc files on import.
 # I normally don't want the .pyc files cluttering up the test directories.

--- a/pandokia/helpers/runner_minipyt.py
+++ b/pandokia/helpers/runner_minipyt.py
@@ -9,7 +9,11 @@ import os.path
 import time
 import gc
 import copy
-import collections
+
+try:
+    import collections
+except ImportError:
+    import collections.abc as collections
 
 # In python 2.6 and later, this prevents writing the .pyc files on import.
 # I normally don't want the .pyc files cluttering up the test directories.


### PR DESCRIPTION
Details in https://github.com/spacetelescope/pandeia/pull/4940
Sister PR https://github.com/spacetelescope/pandeia_test/pull/997

This PR includes **bugfixes**:
 - fixing deprecation warning: collections import -- use `collection.abc` instead just `collection` in python 3
  Warning example:
  ```
  /installations/third_party/py3/envs/test_1/lib/python3.7/site-packages/pandokia-2.4.1.dev34+g0a8770e5-py3.7.egg/pandokia/helpers/runner_minipyt.py:749: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    if isinstance(pycode_fn, collections.Callable):
```


More details about the actual warnings in [JETC-946](https://jira.stsci.edu/browse/JETC-946?focusedCommentId=456471&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-456471)

Test run link:
https://glitch.etc.stsci.edu/jwst/test/reports/user_pandeia_oitl_fix_warnings_JETC-946_2020-04-15-16:41:17.html
(test clean except server third party test, which is expected since the fix for that just merged,
client linux failures are all in firefox, but chrome version are all okay,
and chronic issue in final)

https://glitch.etc.stsci.edu/jwst/test/reports/user_pandeia_oitl_fix_warnings_JETC-946_2020-04-16-10:10:01.html
(up to date with master test - clean except known websocket close issue in final and known client upload page test issue in osx)

https://glitch.etc.stsci.edu/jwst/test/reports/user_pandeia_oitl_fix_warnings_JETC-946_2020-04-16-16:16:22.html
(quick test for final exception watch fix)