### PR TITLE
Raise the actual error that was most recently being handled

### DIFF
--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -498,9 +498,8 @@ def parse_time(arg):
     except ValueError:
         pass
 
-    # didn't match anything?  ok, well the last exception is
-    # as good as anything else we might raise
-    raise ValueError("Could not parse date format")
+    # didn't match anything?
+    raise ValueError("Could not parse time format")
 
 
 def sql_time(d):

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -462,7 +462,7 @@ def parse_time(arg):
         x = float(arg)
         d = datetime.datetime.fromtimestamp(x)
         return d
-    except ValueError as err:
+    except ValueError:
         pass
 
     # sql time:
@@ -479,7 +479,7 @@ def parse_time(arg):
             # not in 2.4:
             # d = datetime.datetime.strptime(arg,'%Y-%m-%d %H:%M:%S')
         return d
-    except ValueError as err:
+    except ValueError:
         pass
 
     # ctime
@@ -488,19 +488,19 @@ def parse_time(arg):
     try:
         d = datetime.datetime.strptime(arg, '%a %b %d %H:%M:%S %Y')
         return d
-    except ValueError as err:
+    except ValueError:
         pass
 
     # just a date
     try:
         d = datetime.datetime.strptime(arg, '%Y-%m-%d')
         return d
-    except ValueError as err:
+    except ValueError:
         pass
 
     # didn't match anything?  ok, well the last exception is
     # as good as anything else we might raise
-    raise err
+    raise ValueError("Could not parse date format")
 
 
 def sql_time(d):

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -462,7 +462,7 @@ def parse_time(arg):
         x = float(arg)
         d = datetime.datetime.fromtimestamp(x)
         return d
-    except ValueError:
+    except ValueError as err:
         pass
 
     # sql time:
@@ -479,7 +479,7 @@ def parse_time(arg):
             # not in 2.4:
             # d = datetime.datetime.strptime(arg,'%Y-%m-%d %H:%M:%S')
         return d
-    except ValueError:
+    except ValueError as err:
         pass
 
     # ctime
@@ -488,19 +488,19 @@ def parse_time(arg):
     try:
         d = datetime.datetime.strptime(arg, '%a %b %d %H:%M:%S %Y')
         return d
-    except ValueError:
+    except ValueError as err:
         pass
 
     # just a date
     try:
         d = datetime.datetime.strptime(arg, '%Y-%m-%d')
         return d
-    except ValueError:
+    except ValueError as err:
         pass
 
     # didn't match anything?  ok, well the last exception is
     # as good as anything else we might raise
-    raise
+    raise err
 
 
 def sql_time(d):


### PR DESCRIPTION
Steuermann interprets not yet filed [(None) as ""](https://github.com/spacetelescope/steuermann/blob/8c3de33ccd998a3fdd0711362a9fb810fd0211bb/steuermann/report.py#L49) and then passes them to pandokia to parse.
Because these are not valid dates of any kind, they fail down to the bottom of the function, where a bare 'raise' was put. This is now causing errors in the HST ETC:

```
RuntimeError: No active exception to reraise
      args = ('No active exception to reraise',)
      with_traceback = <built-in method with_traceback of RuntimeError object> 
```
I think something recently changed with the scope of exception handling in Python, such that "previously in the function" no longer counts as actively being handled. 
(https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement)

I'm storing the exceptions to explicitly re-raise. In theory, saving only the last one should be sufficient, but I think it's tidier to save each of them.