### PR TITLE
For py3.9 use the html module's escape() instead of cgi modules version

### DIFF
--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -13,6 +13,7 @@ import os
 import os.path
 import re
 import types
+from html import escape as html_escape
 
 from six import StringIO
 from six.moves.urllib.parse import urlencode

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -306,7 +306,7 @@ def get_contact(project, test_name, mode='str'):
 #       text    substitute the string exactly with no changes
 #       cgi     if value is a string, quote_plus(value)
 #               else urlencode(value)
-#       html    cgi.escape(string, quote=True)
+#       html    html_escape(string, quote=True)
 #       ''      default format
 #
 # To get a % sign, use "%;"
@@ -359,7 +359,7 @@ def expand(text, dictlist=[], valid=None, format=''):
                         val = urlencode(val)
                     result.write(val)
                 elif this_format == 'html':
-                    val = cgi.escape(str(val), quote=True)
+                    val = html_escape(str(val), quote=True)
                     result.write(val)
                 else:
                     result.write(str(val))

--- a/pandokia/flagok.py
+++ b/pandokia/flagok.py
@@ -3,9 +3,9 @@
 # This is a library routine used by the CGI portion of the flagok operation
 #
 
-import cgi
 import pandokia
 import os.path
+from html import escape as html_escape
 
 import pandokia
 
@@ -13,7 +13,7 @@ pdk_db = pandokia.cfg.pdk_db
 
 
 def noflag(name, err):
-    print('Flagok not possible for %s: %s<br>' % (cgi.escape(name), err))
+    print('Flagok not possible for %s: %s<br>' % (html_escape(name), err))
 
 
 def ok_transaction(qid, client, key_ids, user, comment):
@@ -80,8 +80,8 @@ def flagok(key_id, trans_id):
     flagfile = pandokia.cfg.flagok_file % host
     print(
         "OK %s %s %s<br>" %
-        (cgi.escape(test_name),
-         cgi.escape(flagok_file),
+        (html_escape(test_name),
+         html_escape(flagok_file),
          flagfile))
 
     pdk_db.execute(

--- a/pandokia/pcgi_action.py
+++ b/pandokia/pcgi_action.py
@@ -5,11 +5,11 @@
 #
 
 import sys
-import cgi
 import re
 import copy
 import time
 import os
+from html import escape as html_escape
 
 import pandokia
 import pandokia.text_table as text_table
@@ -212,7 +212,7 @@ def run():
         output.write('<input type=hidden name=save_comment value=1>')
         output.write(
             '<textarea cols="80" rows="10" name=comment>%s</textarea><br>' %
-            (cgi.escape(note)))
+            (html_escape(note)))
         output.write('<input type=submit value="save">')
         output.write('</form>')
 

--- a/pandokia/pcgi_day_report.py
+++ b/pandokia/pcgi_day_report.py
@@ -5,7 +5,7 @@
 
 #
 import sys
-import cgi
+from html import escape as html_escape
 import re
 import copy
 import time
@@ -166,7 +166,7 @@ def rpt1():
     if pandokia.pcgi.output_format == 'html':
         sys.stdout.write(common.cgi_header_html)
         sys.stdout.write(common.page_header())
-        sys.stdout.write('<h2>%s</h2>' % cgi.escape(test_run))
+        sys.stdout.write('<h2>%s</h2>' % html_escape(test_run))
         sys.stdout.write(table.get_html(headings=1))
         sys.stdout.write(
             "<br>Click on the ! to mark a test run as too valuable to delete\n")
@@ -263,7 +263,7 @@ def rpt2():
 # # # # # # # # # #
     if pandokia.pcgi.output_format == 'html':
 
-        header = "<big><big><b>" + cgi.escape(test_run) + "</b></big></big>\n"
+        header = "<big><big><b>" + html_escape(test_run) + "</b></big></big>\n"
 
         if 1:
             # if it looks like there is a date in it, try to show the day of the week
@@ -322,10 +322,10 @@ def rpt2():
         if 1:
             if test_run_note.startswith('*'):
                 header = header + \
-                    '<p>\nNote: %s</p>' % (cgi.escape(test_run_note))
+                    '<p>\nNote: %s</p>' % (html_escape(test_run_note))
             else:
                 header = header + '<p><form action=%s>\nNote: <input type=text name=note value="%s" size=%d>\n<input type=hidden name=test_run value="%s">\n<input type=hidden name=query value=action></form></p>' % (
-                    common.get_cgi_name(), cgi.escape(test_run_note), len(test_run_note) + 20, test_run)
+                    common.get_cgi_name(), html_escape(test_run_note), len(test_run_note) + 20, test_run)
 
             if test_run_valuable:
                 header = header + '<p>valuable '
@@ -341,7 +341,7 @@ def rpt2():
         # write links to the top of each project
         sys.stdout.write('<p>\n')
         for p in projects:
-            p = cgi.escape(p)
+            p = html_escape(p)
             sys.stdout.write('<a href="#%s">%s</a>&nbsp;&nbsp; ' % (p, p))
         sys.stdout.write('</p>\n')
 
@@ -455,7 +455,7 @@ def gen_daily_table(
             link = common.selflink(query_dict=query, linkmode="treewalk")
 
             # the heading for a project subsection of the table
-            project_text = cgi.escape(project)
+            project_text = html_escape(project)
             project_text = '<hr><big><strong><b><a name="%s" href="%s">%s</a></b></strong></big>' % (
                 project_text, link, project_text)
             table.set_value(row, 0, text=project, html=project_text)

--- a/pandokia/pcgi_detail.py
+++ b/pandokia/pcgi_detail.py
@@ -4,11 +4,11 @@
 #
 
 import sys
-import cgi
 import re
 import copy
 import time
 import datetime
+from html import escape as html_escape
 
 import pandokia.text_table as text_table
 import pandokia.pcgi
@@ -357,7 +357,7 @@ def do_result(key_id):
 
 
                 sys.stdout.write("Log:<br><pre>")
-                sys.stdout.write(cgi.escape(y))
+                sys.stdout.write(html_escape(y))
                 sys.stdout.write("</pre>\n")
 
         sys.stdout.write("<br>\n")

--- a/pandokia/pcgi_misc.py
+++ b/pandokia/pcgi_misc.py
@@ -4,7 +4,7 @@
 #
 
 import sys
-import cgi
+from html import escape as html_escape
 
 import pandokia
 import pandokia.pcgi
@@ -26,7 +26,7 @@ def hostinfo():
         if description is None:
             description = ''
 
-        print('<b>%s</b><br>' % cgi.escape(host))
+        print('<b>%s</b><br>' % html_escape(host))
 
         cols = len(os)
         if cols < 40:
@@ -36,7 +36,7 @@ def hostinfo():
             print("<input type=hidden name=query value=set_hostinfo>")
             print("<input type=hidden name=host value=%s>" % host)
         print('<input type=text cols=%d name=os value="%s">' %
-              (cols, cgi.escape(os, True)))
+              (cols, html_escape(os, True)))
 
         l = [len(s) for s in description.split('\n')]
         cols = max(l)
@@ -47,7 +47,7 @@ def hostinfo():
             rows = 4
         print(
             "<br><textarea name=description rows=%d cols=%d>%s</textarea>" %
-            (rows, cols, cgi.escape(description)))
+            (rows, cols, html_escape(description)))
         if admin:
             print("<br><input type=submit value='change'>")
             print("</form>")

--- a/pandokia/pcgi_preferences.py
+++ b/pandokia/pcgi_preferences.py
@@ -6,7 +6,7 @@
 #
 
 import sys
-import cgi
+from html import escape as html_escape
 
 try:
     from urllib.parse import quote
@@ -88,7 +88,7 @@ def show(user):
     form = pandokia.pcgi.form
 
     #
-    output.write('<h1>User Preferences: %s</h1>' % cgi.escape(user))
+    output.write('<h1>User Preferences: %s</h1>' % html_escape(user))
 
     # write the start of form, including hidden fields needed to dispatch
     # to the save() function after we submit the form.
@@ -229,7 +229,7 @@ def add_project(user):
             (user,
              project))
         cfg.pdk_db.commit()
-        output.write('added %s' % cgi.escape(project))
+        output.write('added %s' % html_escape(project))
 
     output.write('<br>')
     output.write(
@@ -325,7 +325,7 @@ def list_users():
         " SELECT DISTINCT username FROM user_email_pref WHERE "
         " username NOT IN ( SELECT username FROM user_prefs ) ")
     for x, in c:
-        print("user %s not in user_prefs table - adding<br>" % cgi.escape(x))
+        print("user %s not in user_prefs table - adding<br>" % html_escape(x))
         cfg.pdk_db.execute(
             "INSERT INTO user_prefs ( username ) VALUES ( :1 )", (x,))
     cfg.pdk_db.commit()
@@ -364,7 +364,7 @@ def list_users():
             # stuff that preference into the table.
             if m is not None:
                 f = '%s %s' % (f, m)
-            tb.set_value(row, 'p.' + p, cgi.escape(f))
+            tb.set_value(row, 'p.' + p, html_escape(f))
 
         row = row + 1
 

--- a/pandokia/pcgi_qid_op.py
+++ b/pandokia/pcgi_qid_op.py
@@ -8,11 +8,11 @@
 #
 
 import sys
-import cgi
 import re
 import copy
 import time
 import os
+from html import escape as html_escape
 
 import pandokia
 pdk_db = pandokia.cfg.pdk_db
@@ -191,13 +191,13 @@ def qid_list():
         t.set_value(row, 1, v)
 
         v = str(x[2])
-        t.set_value(row, 2, v, html=cgi.escape(v))
+        t.set_value(row, 2, v, html=html_escape(v))
 
         if x[3] is None:
             v = ''
         else:
             v = str(x[3])
-        t.set_value(row, 3, v, html='<pre>' + cgi.escape(v) + '</pre>')
+        t.set_value(row, 3, v, html='<pre>' + html_escape(v) + '</pre>')
 
         row = row + 1
 

--- a/pandokia/pcgi_summary.py
+++ b/pandokia/pcgi_summary.py
@@ -4,12 +4,12 @@
 #
 
 import sys
-import cgi
 import re
 import copy
 import time
-import pandokia.lib as lib
+from html import escape as html_escape
 
+import pandokia.lib as lib
 import pandokia.text_table as text_table
 
 try:
@@ -103,7 +103,7 @@ def qid_block(qid):
             qdict,
             linkmode="action") +
         "'>")
-    output.write('Comment:</a><br><pre>%s</pre>\n' % cgi.escape(notes))
+    output.write('Comment:</a><br><pre>%s</pre>\n' % html_escape(notes))
 
 
 ##########
@@ -224,7 +224,7 @@ def run():
     <input type=submit name=x_submit value='same'>
     <input type=submit name=x_submit value='different'>
     </form>
-    """ % (pandokia.pcgi.cginame, qid, show_attr, cgi.escape(cmp_run)))
+    """ % (pandokia.pcgi.cginame, qid, show_attr, html_escape(cmp_run)))
 
         #
         output.write("""
@@ -235,7 +235,7 @@ def run():
     <input type=hidden name=cmp_run value='%s'>
     <input type=submit name=x_submit value='Add Attributes'>
     </form>
-    """ % (pandokia.pcgi.cginame, qid, cgi.escape(cmp_run)))
+    """ % (pandokia.pcgi.cginame, qid, html_escape(cmp_run)))
 
         qid_block(qid)
 
@@ -295,22 +295,22 @@ def run():
         if len(all_test_run) == 1:
             result_table.suppress("test_run")
             output.write("<h3>test_run: " +
-                         cgi.escape([tmp for tmp in all_test_run][0]) +
+                         html_escape([tmp for tmp in all_test_run][0]) +
                          "</h3>")
         if len(all_project) == 1:
             result_table.suppress("project")
             output.write("<h3>project: " +
-                         cgi.escape([tmp for tmp in all_project][0]) +
+                         html_escape([tmp for tmp in all_project][0]) +
                          "</h3>")
         if len(all_host) == 1:
             result_table.suppress("host")
             output.write("<h3>host: " +
-                         cgi.escape([tmp for tmp in all_host][0]) +
+                         html_escape([tmp for tmp in all_host][0]) +
                          "</h3>")
         if len(all_context) == 1:
             result_table.suppress("context")
             output.write("<h3>context: " +
-                         cgi.escape([tmp for tmp in all_context][0]) +
+                         html_escape([tmp for tmp in all_context][0]) +
                          "</h3>")
         if len(all_custom) == 1:
             first_custom = [tmp for tmp in all_custom][0]
@@ -319,7 +319,7 @@ def run():
             if first_custom == '':
                 custom_title = "None"
             else:
-                custom_title = cgi.escape(first_custom)
+                custom_title = html_escape(first_custom)
             output.write("<h3>custom: " + custom_title + "</h3>")
         # suppressing the columns that are the same for every row
         same_table = suppress_attr_all_same(result_table, column_select_values)

--- a/pandokia/text_table.py
+++ b/pandokia/text_table.py
@@ -9,13 +9,9 @@
 
 __all__ = ["text_table"]
 
-try:
-    import cgi as html
-except ImportError:
-    import html
-
 import csv
 import sys
+from html import escape as html_escape
 
 try:
     import StringIO
@@ -521,7 +517,7 @@ class text_table:
                     s.write(self.title_html[colcount])
                 elif self.title_links[colcount]:
                     s.write("<a href='" + self.title_links[colcount] + "'>")
-                    s.write(html.escape(str(r)))
+                    s.write(html_escape(str(r)))
                     s.write("</a>")
                 else:
                     s.write(r)
@@ -569,7 +565,7 @@ class text_table:
                         if c.text is not None and c.code:
                             s.write("<pre>{}</pre>".format(c.text))
                         elif c.text is not None and not c.code:
-                            s.write(html.escape(str(c.text)))
+                            s.write(html_escape(str(c.text)))
                         else:
                             s.write("&nbsp;")
                     if c.link:


### PR DESCRIPTION
For:  https://jira.stsci.edu/browse/JETC-1934

When trying to run pyetc with Python3.9 (TP12) we see an old usage of `cgi.escape()` has bitten us.  We should have moved on to using `html.escape()` before now.

In Python 3.7 we got deprecation warnings and obviously never noticed them (in both HETC and in JETC):
```
Python 3.7.7 (default, Mar 26 2020, 10:32:53) 
[Clang 4.0.1 (tags/RELEASE_401/final)] :: Anaconda, Inc. on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> import cgi, html
>>> 
>>> cgi.escape('blah < aaa > bbb & and')
__main__:1: DeprecationWarning: cgi.escape is deprecated, use html.escape instead
'blah &lt; aaa &gt; bbb &amp; and'
>>> 
>>> html.escape('blah < aaa > bbb & and')
'blah &lt; aaa &gt; bbb &amp; and'
>>> 
```

In Python 3.9 it no longer exists in cgi:
```
Python 3.9.1 (default, Jan 11 2021, 15:10:49) 
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import cgi
>>> cgi.escape('blah < aaa > bbb & and')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'cgi' has no attribute 'escape'
```

This fix changes the use of the `cgi` package (which in these files is ONLY used for the `escape()` function) to use the `html` package.  However, I change it to import ONLY the escape() function, and I name it uniquely to "html_escape" so as to avoid future clashes with the name of the `html` package and the many many uses of "html" as a variable and a function parameter throughout pandokia.