### PR TITLE
Ensure html.escape() gets str type input

### DIFF
--- a/pandokia/flagok.py
+++ b/pandokia/flagok.py
@@ -13,7 +13,7 @@ pdk_db = pandokia.cfg.pdk_db
 
 
 def noflag(name, err):
-    print('Flagok not possible for %s: %s<br>' % (html_escape(name), err))
+    print('Flagok not possible for %s: %s<br>' % (html_escape(str(name)), err))
 
 
 def ok_transaction(qid, client, key_ids, user, comment):
@@ -80,8 +80,8 @@ def flagok(key_id, trans_id):
     flagfile = pandokia.cfg.flagok_file % host
     print(
         "OK %s %s %s<br>" %
-        (html_escape(test_name),
-         html_escape(flagok_file),
+        (html_escape(str(test_name)),
+         html_escape(str(flagok_file)),
          flagfile))
 
     pdk_db.execute(

--- a/pandokia/pcgi_action.py
+++ b/pandokia/pcgi_action.py
@@ -204,6 +204,8 @@ def run():
         note = c.fetchone()[0]
         if note is None:
             note = ''
+        if type(note) == bytes:
+            note = note.decode()
         output.write(
             '<form action=%s method=get name=edit_comment>' %
             pandokia.pcgi.cginame)

--- a/pandokia/pcgi_detail.py
+++ b/pandokia/pcgi_detail.py
@@ -344,6 +344,9 @@ def do_result(key_id):
 
             (y, ) = y
 
+            if type(y) == bytes:
+                y = y.decode()
+
             if y != "":
                 if getattr(cfg, 'enable_magic_html_log'):
                     if '<!DOCTYPE' in y or '<html' in y:

--- a/pandokia/pcgi_summary.py
+++ b/pandokia/pcgi_summary.py
@@ -43,6 +43,8 @@ def qid_block(qid):
         if claimant == '':
             claimant = None
         notes = x[2]
+        if type(notes) == bytes:
+            notes = notes.decode()
     else:
         expires = None
         claimant = None


### PR DESCRIPTION
The last PR changed the use of `cgi.escape()` to `html.escape()`.  Apparently the old (now gone) `cgi.escape()` was more forgiving of mixed/wrong string types being thrown around.

This PR takes the most likely places for problems (text chunk reads from sql) and checks that they are `str` (converts if needed).

This is *intentionally* not an exhaustive scan of all pandokia code because:
- 1) we don't use it all and we don't support it all
- 2) we don't have time for this

This PR SHOULD get us back up and running for all of our **_standard_** pdk uses.