### PR TITLE
PDK_CUSTOM expects a string not None

### DIFF
--- a/pandokia/run.py
+++ b/pandokia/run.py
@@ -69,7 +69,7 @@ def run(args):
     test_run = os.environ.get("PDK_TESTRUN", None)
     test_prefix = os.environ.get("PDK_TESTPREFIX", None)
     context = os.environ.get("PDK_CONTEXT", 'default')
-    custom = os.environ.get("PDK_CUSTOM", None)
+    custom = os.environ.get("PDK_CUSTOM", "")
     parallel = os.environ.get("PDK_PARALLEL", None)
     tmpdir = os.environ.get("PDK_TMP", None)
     host = os.environ.get("PDK_HOST", None)


### PR DESCRIPTION
```
$ pdk run -r .
DEFAULT TEST RUN user_example_2021-08-22-23-28-30
Traceback (most recent call last):
  File "/tmp/pdk/bin/pdk", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/path/to/pandokia/scripts/pdk", line 46, in <module>
    sys.exit(pandokia.entry.run())
  File "/path/to/pandokia/pandokia/entry.py", line 182, in run
    (err, lstat) = x.run(args)
  File "/path/to/pandokia/pandokia/run.py", line 137, in run
    os.environ['PDK_CUSTOM'] = custom
  File "/usr/lib/python3.9/os.py", line 684, in __setitem__
    value = self.encodevalue(value)
  File "/usr/lib/python3.9/os.py", line 756, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not NoneType
```

I don't know about the other environment variables listed in the same initialization block. They should probably be examined too.  Anyway... setting the default value to an empty string prevents ^this^ exception from happening, negating the need to put `export PDK_CUSTOM=""` in various scripts.

Fixes #60