### PR TITLE
JETC-2956: Remove deprecations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,5 @@ prune .git
 prune doc/build
 prune build
 prune dist
-prune relic
 exclude pandokia/version.py
 exclude *.pyc *.pyo

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ RE_GIT_DESC = re.compile(r'v?(.+?)-(\d+)-g(\w+)-?(.+)?')
 
 # Versioning
 try:
-    version = str(subprocess.check_output(["git", "describe", "--tags", "--always", "--dirty"]), encoding="utf-8").strip()
+    version = str(subprocess.check_output(["git", "describe", "--tags", "--always", "--abbrev=8", "--dirty"]), encoding="utf-8").strip()
     with open('RELIC-INFO', 'w') as versionfile:
-        outdict = {"raw": version}
+        outdict = {"long": version}
         json.dump(outdict, versionfile)
 except (subprocess.CalledProcessError, FileNotFoundError) as err:
     print(err)
     with open("RELIC-INFO") as versionfile:
-        version = json.load(versionfile)["raw"]
+        version = json.load(versionfile)["long"]
 
 shortver, num, commit, dirty_check = RE_GIT_DESC.match(version).groups()
 

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ classifiers = [
     # 'Operating System :: Microsoft :: Windows',
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Unix',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python
 # basic imports
+import re
 import os
 import sys
 from setuptools import setup, find_packages
 import subprocess
 
+RE_GIT_DESC = re.compile('v?(.+?)-(\d+)-g(\w+)-?(.+)?')
 
 # Versioning
 try:
-    version = subprocess.check_output(["git", "describe", "--tags"])
-    with open('RELIC-INFO', 'wb') as versionfile:
+    version = str(subprocess.check_output(["git", "describe", "--tags", "--always", "--dirty"]), encoding="utf-8")
+    with open('RELIC-INFO', 'w') as versionfile:
         versionfile.write(version)
 except (subprocess.CalledProcessError, FileNotFoundError) as err:
     print(err)
     with open("RELIC-INFO") as versionfile:
         version = versionfile.read()
+
+shortver, num, commit, dirty_check = RE_GIT_DESC.match(version).groups()
+
+version = f"{shortver}.dev{num}+g{commit}"
 
 ##
 #

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ import subprocess
 
 RE_GIT_DESC = re.compile(r'v?(.+?)-(\d+)-g(\w+)-?(.+)?')
 
-# Versioning
+# Versioning 
+# Not actually using Relic (but reimplementing the important part of its functionality)
+# means that you cannot downgrade to older versions of Pandokia without manually deleting
+# RELIC-INFO
 try:
     version = str(subprocess.check_output(["git", "describe", "--tags", "--always", "--abbrev=8", "--dirty"]), encoding="utf-8").strip()
     with open('RELIC-INFO', 'w') as versionfile:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # basic imports
 import re
 import os
-import sys
+import json
 from setuptools import setup, find_packages
 import subprocess
 
@@ -10,13 +10,14 @@ RE_GIT_DESC = re.compile(r'v?(.+?)-(\d+)-g(\w+)-?(.+)?')
 
 # Versioning
 try:
-    version = str(subprocess.check_output(["git", "describe", "--tags", "--always", "--dirty"]), encoding="utf-8")
+    version = str(subprocess.check_output(["git", "describe", "--tags", "--always", "--dirty"]), encoding="utf-8").strip()
     with open('RELIC-INFO', 'w') as versionfile:
-        versionfile.write(version)
+        outdict = {"raw": version}
+        json.dump(outdict, versionfile)
 except (subprocess.CalledProcessError, FileNotFoundError) as err:
     print(err)
     with open("RELIC-INFO") as versionfile:
-        version = versionfile.read()
+        version = json.load(versionfile)["raw"]
 
 shortver, num, commit, dirty_check = RE_GIT_DESC.match(version).groups()
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 from setuptools import setup, find_packages
 import subprocess
 
-RE_GIT_DESC = re.compile('v?(.+?)-(\d+)-g(\w+)-?(.+)?')
+RE_GIT_DESC = re.compile(r'v?(.+?)-(\d+)-g(\w+)-?(.+)?')
 
 # Versioning
 try:


### PR DESCRIPTION
Pandokia was written to use either setuptools or distutils; distutils is now due for removal (it's been deprecated since 2014) so I've removed that from the installer.

I also removed the dependency on relic, by including the minimal parts of relic that reproduce the version naming functionality.

See companion PRs in Pandeia ([#5728](https://github.com/spacetelescope/pandeia/pull/5728)) and Pandeia Test ([#1482](https://github.com/spacetelescope/pandeia_test/pull/1482))

Test run link(s):
https://glitch.etc.stsci.edu/jwst/test/reports/user_pandeia_jwst_arr_deprecations_JETC-2956_2022-11-29-16:59:22.html