### PR TITLE
One other place we relied on relic

### DIFF
--- a/pandokia/__init__.py
+++ b/pandokia/__init__.py
@@ -12,7 +12,9 @@ describe pandokia a little
 
 import os
 import sys
-from .version import *
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution('pandokia').version
 
 
 # A simple boolean check for python 3.0.0.final or greater


### PR DESCRIPTION
Pandokia tried to install relic for its versioning, and to create a version.py file pandokia itself would load. With a fresh install that never HAD the relic-version in it, version.py is missing and pandokia can't be imported (even into its own installer).

pandokia's `__init__.py` loads all of the strings in version.py into itself; the only one pandokia uses (after examination) is `__version__`, and that only in the Sphinx documentation configuration.

This PR replaces the reliance on the sphinx files with the same setuptools command the Pandeia Engine uses. It's possible external tools still rely upon the other properties relic created (`__version__`, `__version_short__`, `__version_long__`, `__version_post__`, `__version_commit__`, `__version_date__`, `__version_dirty__`, `__build_date__`, `__build_time__`, `__build_status__`) but this PR allows us to install pandokia in fresh places.