### PR TITLE
JETC-3344: Make Pandokia versioning handle releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 # basic imports
-import re
 import os
 import json
 from setuptools import setup, find_packages
 import subprocess
-
-RE_GIT_DESC = re.compile(r'v?(.+?)-(\d+)-g(\w+)-?(.+)?')
 
 # Versioning 
 # Not actually using Relic (but reimplementing the important part of its functionality)
@@ -21,10 +18,17 @@ except (subprocess.CalledProcessError, FileNotFoundError) as err:
     print(err)
     with open("RELIC-INFO") as versionfile:
         version = json.load(versionfile)["long"]
+components = version.split("-")
+if len(components) <= 2:
+    # if there are 1 or 2, it's (tag) or (tag)-dirty
+    version = components[0]
+elif len(components) >= 3:
+    shortver, num, commit, *dirty_check = components
+    version = f"{shortver}.dev{num}+g{commit[1:]}"
+else:
+    raise ValueError("Could not parse version string")
 
-shortver, num, commit, dirty_check = RE_GIT_DESC.match(version).groups()
 
-version = f"{shortver}.dev{num}+g{commit}"
 
 ##
 #

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 # basic imports
+import re
 import os
 import json
 from setuptools import setup, find_packages
 import subprocess
+
+RE_GIT_DESC = re.compile(r'v?(.+?)-(\d+)-g(\w+)-?(.+)?')
 
 # Versioning 
 # Not actually using Relic (but reimplementing the important part of its functionality)
@@ -18,17 +21,13 @@ except (subprocess.CalledProcessError, FileNotFoundError) as err:
     print(err)
     with open("RELIC-INFO") as versionfile:
         version = json.load(versionfile)["long"]
-components = version.split("-")
-if len(components) <= 2:
-    # if there are 1 or 2, it's (tag) or (tag)-dirty
-    version = components[0]
-elif len(components) >= 3:
-    shortver, num, commit, *dirty_check = components
-    version = f"{shortver}.dev{num}+g{commit[1:]}"
+
+match = RE_GIT_DESC.match(version)
+if match is not None:
+    shortver, num, commit, dirty_check = match.groups()
+    version = f"{shortver}.dev{num}+g{commit}"
 else:
-    raise ValueError("Could not parse version string")
-
-
+    version = version.split("-")[0] # just in case -dirty is in the version string
 
 ##
 #


### PR DESCRIPTION
Make pandokia versioning work better, and stop the problem we were having with the rc tag from happening again.

The ultimate problem was that the regular expression is looking for a string of the pattern "2.0-15-g70aedc3e-dirty" in the output of `git describe --tags --always --abbrev=8 --dirty`
which is to say _someCharacters_-_decimalNumber_-g _unicodeCharacters_-_anythingElse_
If you try to install exactly from a tag ("2.1rc1"), it doesn't fit the pattern, so, as [the documentation says](https://docs.python.org/3/library/re.html#re.search), it returns `None`.

Relic got around this issue by looking for the `None` and just printing the version string it got (minus a "-dirty" if it was there).

This could also be done with str.split() instead of a regular expression, though a little less sophisticated as it wouldn't be looking for the "g" in the commit field.

Tested on tags and non-tag commits.