### PR TITLE
JETC-1051: Remove use of the imp module

### DIFF
--- a/pandokia/__init__.py
+++ b/pandokia/__init__.py
@@ -12,9 +12,9 @@ describe pandokia a little
 
 import os
 import sys
-import pkg_resources
+from importlib.metadata import version
 
-__version__ = pkg_resources.get_distribution('pandokia').version
+__version__ = version('pandokia')
 
 
 # A simple boolean check for python 3.0.0.final or greater

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -15,9 +15,9 @@ import re
 import types
 from html import escape as html_escape
 
-from six import StringIO
-from six.moves.urllib.parse import urlencode
-from six.moves.urllib.parse import quote_plus
+from io import StringIO
+from urllib.parse import urlencode
+from urllib.parse import quote_plus
 
 import pandokia
 cfg = pandokia.cfg

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -18,10 +18,22 @@ from html import escape as html_escape
 from io import StringIO
 from urllib.parse import urlencode
 from urllib.parse import quote_plus
+import importlib.util
+import importlib.machinery
 
 import pandokia
 cfg = pandokia.cfg
 
+# replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 ######
 #--#--# CGI

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -25,6 +25,7 @@ import pandokia
 cfg = pandokia.cfg
 
 # replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
+# see similar usage in steuermann config.py
 def load_source(modname, filename):
     loader = importlib.machinery.SourceFileLoader(modname, filename)
     spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)

--- a/pandokia/db_sqlite.py
+++ b/pandokia/db_sqlite.py
@@ -16,22 +16,15 @@ __all__ = [
 
 # system imports
 import os
-
-try:
-    import StringIO
-except ImportError:
-    import io as StringIO
+import io
 
 
 # need some common code
 import pandokia.db
 
 # The database engine is named "sqlite3" if it was installed with
-# python, or "pyqslite2" if it was installed separately.
-try:
-    import sqlite3 as db_module
-except ImportError:
-    import pysqlite2.dbapi2 as db_module
+# python, or "pysqlite2" if it was installed separately.
+import sqlite3 as db_module
 
 # from dbapi
 threadsafety = db_module.threadsafety
@@ -135,7 +128,7 @@ class PandokiaDB(pandokia.db.where_dict_base):
     def explain_query(self, text, query_dict=None):
         print("TEXT %s" % text)
         print("DICT %s" % query_dict)
-        f = StringIO.StringIO()
+        f = io.StringIO()
         c = self.execute('EXPLAIN QUERY PLAN ' + text, query_dict)
         for x in c:
             f.write(str(x))

--- a/pandokia/default_config.py
+++ b/pandokia/default_config.py
@@ -199,7 +199,7 @@ server_maintenance = False
 # is available, but if we are not running in the context of a web server,
 # we use this value.
 #
-cginame = "https://ssb.stsci.edu/pandokia/pdk.cgi"
+cginame = "https://plglitch.stsci.edu/pandokia/pdk.cgi"
 
 #
 # list of known status values, in order they appear on reports

--- a/pandokia/gen_expected.py
+++ b/pandokia/gen_expected.py
@@ -15,7 +15,6 @@
 #       fills in missing tests in test_run_to_check
 #
 #
-from __future__ import print_function
 
 debug = 0
 

--- a/pandokia/helpers/importer.py
+++ b/pandokia/helpers/importer.py
@@ -1,8 +1,20 @@
 '''import an arbitrary file with an arbitrary module name
 '''
 import sys
-import imp
 
+import importlib.util
+import importlib.machinery
+
+# replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 def importer(modulename, filename):
 
@@ -12,7 +24,7 @@ def importer(modulename, filename):
     save = sys.dont_write_bytecode
     try:
         sys.dont_write_bytecode = True
-        m = imp.load_source(modulename, filename, f)
+        m = load_source(modulename, filename, f)
     finally:
         f.close()
         sys.dont_write_bytecode = save

--- a/pandokia/helpers/importer.py
+++ b/pandokia/helpers/importer.py
@@ -2,19 +2,9 @@
 '''
 import sys
 
-import importlib.util
-import importlib.machinery
+from ..common import load_source
 
-# replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
-def load_source(modname, filename):
-    loader = importlib.machinery.SourceFileLoader(modname, filename)
-    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
-    module = importlib.util.module_from_spec(spec)
-    # The module is always executed and not cached in sys.modules.
-    # Uncomment the following line to cache the module.
-    # sys.modules[module.__name__] = module
-    loader.exec_module(module)
-    return module
+
 
 def importer(modulename, filename):
 

--- a/pandokia/helpers/runner_minipyt.py
+++ b/pandokia/helpers/runner_minipyt.py
@@ -4,8 +4,7 @@
 import sys
 import inspect
 import traceback
-import importlib.util
-import importlib.machinery
+from ..common import load_source
 import os.path
 import time
 import gc
@@ -572,17 +571,6 @@ def run_test_class(rpt, mod, name, ob, test_order):
         run_test_class_multiple(rpt, mod, name, ob, test_order)
     else:
         run_test_class_single(rpt, mod, name, ob, test_order)
-
-# replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
-def load_source(modname, filename):
-    loader = importlib.machinery.SourceFileLoader(modname, filename)
-    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
-    module = importlib.util.module_from_spec(spec)
-    # The module is always executed and not cached in sys.modules.
-    # Uncomment the following line to cache the module.
-    # sys.modules[module.__name__] = module
-    loader.exec_module(module)
-    return module
 
 
 ####

--- a/pandokia/helpers/runner_unit2.py
+++ b/pandokia/helpers/runner_unit2.py
@@ -1,7 +1,8 @@
 import sys
 import time
 import traceback
-import imp
+import importlib.util
+import importlib.machinery
 import os.path
 
 no_unittest2 = False
@@ -19,6 +20,17 @@ unittest2_versions = ('0.3.0', '0.4.0', '0.4.2', '0.5.1')
 
 
 from pandokia.helpers import pycode
+
+# replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 ###
 # This part of the file provides objects that are instantiated
@@ -217,7 +229,7 @@ def main(args):
 
         try:
 
-            module = imp.load_source(module_name, filename)
+            module = load_source(module_name, filename)
 
             # This is a trick to pass a value to the initializer
             # pdk_test_result.  It would be hard to go through channels

--- a/pandokia/helpers/runner_unit2.py
+++ b/pandokia/helpers/runner_unit2.py
@@ -1,8 +1,7 @@
 import sys
 import time
 import traceback
-import importlib.util
-import importlib.machinery
+from ..common import load_source
 import os.path
 
 no_unittest2 = False
@@ -20,17 +19,6 @@ unittest2_versions = ('0.3.0', '0.4.0', '0.4.2', '0.5.1')
 
 
 from pandokia.helpers import pycode
-
-# replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
-def load_source(modname, filename):
-    loader = importlib.machinery.SourceFileLoader(modname, filename)
-    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
-    module = importlib.util.module_from_spec(spec)
-    # The module is always executed and not cached in sys.modules.
-    # Uncomment the following line to cache the module.
-    # sys.modules[module.__name__] = module
-    loader.exec_module(module)
-    return module
 
 ###
 # This part of the file provides objects that are instantiated

--- a/pandokia/import_data.py
+++ b/pandokia/import_data.py
@@ -2,15 +2,13 @@
 # pandokia - a test reporting and execution system
 # Copyright 2009, Association of Universities for Research in Astronomy (AURA)
 #
-from __future__ import print_function
-
 import re
 import sys
 import hashlib
 import pandokia.common as common
 import pandokia
 
-from six import StringIO
+from io import StringIO
 
 #Define some constants based on database schema.
 #TRAs and TDAs have the same lengths; use TXA as shorthand.

--- a/pandokia/pcgi.py
+++ b/pandokia/pcgi.py
@@ -13,7 +13,6 @@ import cgi
 import os
 import os.path
 import sys
-import cgitb
 
 import pandokia
 import pandokia.common as common
@@ -38,8 +37,6 @@ def form_to_dict(f):
 
 def run():
 
-    if cfg.debug:
-        cgitb.enable()
 
     if cfg.server_maintenance:
         sys.stdout.write(

--- a/pandokia/runners/snout.py
+++ b/pandokia/runners/snout.py
@@ -24,7 +24,7 @@ import os.path
 # is a.b.c?", so we have find_module_location() to provide that
 # service.
 
-import imp
+from importlib import util as importutil
 
 
 def find_module_location(name, path=None):
@@ -33,16 +33,14 @@ def find_module_location(name, path=None):
         # have to do it yourself if there is a . in the name.
         l = name.split('.', 1)
         # find the top level package
-        (file, pathname, description) = imp.find_module(l[0], path)
-        if file is not None:
-            file.close()
+        spec = importutil.find_spec(l[0], path)
+        pathname = spec.__file__
         # find the remaining packages in the directory that it was in
         return find_module_location(l[1], [pathname])
     else:
         # If no . in the name, we have it on the first try.
-        (file, pathname, description) = imp.find_module(name, path)
-        if file is not None:
-            file.close()
+        spec = importutil.find_spec(name, path)
+        pathname = spec.__file__
         return pathname
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ except (subprocess.CalledProcessError, FileNotFoundError) as err:
 match = RE_GIT_DESC.match(version)
 if match is not None:
     shortver, num, commit, dirty_check = match.groups()
+    shortver = shortver.split("-")[0]
     version = f"{shortver}.dev{num}+g{commit}"
 else:
     version = version.split("-")[0] # just in case -dirty is in the version string


### PR DESCRIPTION
In addition to replacing the imp module code with the suggested replacements, this PR also:
* Removes use of pkg_resources (also deprecated)
* Removes the last use of six
* Removes the last use of `__future__`
* Cleaned up some other code that produced out of date import statements; basically, we're never going to run Pandokia on Python 2 again, so we don't need those if statements.
* tweaks the code in setup.py that sets the version to still produce valid version numbers even though we're now including version-mission in our tags.

See also PR https://github.com/spacetelescope/pandeia_test/pull/1741
and https://github.com/spacetelescope/steuermann/pull/7