### PR TITLE
JETC-4372: Remove the part where pandokia setup imports pandokia

### DIFF
--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -18,23 +18,11 @@ from html import escape as html_escape
 from io import StringIO
 from urllib.parse import urlencode
 from urllib.parse import quote_plus
-import importlib.util
-import importlib.machinery
 
 import pandokia
 cfg = pandokia.cfg
 
-# replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
-# see similar usage in steuermann config.py
-def load_source(modname, filename):
-    loader = importlib.machinery.SourceFileLoader(modname, filename)
-    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
-    module = importlib.util.module_from_spec(spec)
-    # The module is always executed and not cached in sys.modules.
-    # Uncomment the following line to cache the module.
-    # sys.modules[module.__name__] = module
-    loader.exec_module(module)
-    return module
+
 
 ######
 #--#--# CGI

--- a/pandokia/helpers/importer.py
+++ b/pandokia/helpers/importer.py
@@ -20,12 +20,10 @@ def importer(modulename, filename):
 
     if modulename in sys.modules:
         return sys.modules[modulename]
-    f = open(filename, "r")
     save = sys.dont_write_bytecode
     try:
         sys.dont_write_bytecode = True
-        m = load_source(modulename, filename, f)
+        m = load_source(modulename, filename)
     finally:
-        f.close()
         sys.dont_write_bytecode = save
     return m

--- a/pandokia/helpers/importer.py
+++ b/pandokia/helpers/importer.py
@@ -1,10 +1,20 @@
 '''import an arbitrary file with an arbitrary module name
 '''
 import sys
+import importlib.util
+import importlib.machinery
 
-from ..common import load_source
-
-
+# replacement for imp.load_source() from https://docs.python.org/dev/whatsnew/3.12.html#imp
+# see similar usage in steuermann config.py
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 def importer(modulename, filename):
 

--- a/pandokia/helpers/runner_minipyt.py
+++ b/pandokia/helpers/runner_minipyt.py
@@ -4,7 +4,7 @@
 import sys
 import inspect
 import traceback
-from ..common import load_source
+from .importer import load_source
 import os.path
 import time
 import gc

--- a/pandokia/helpers/runner_unit2.py
+++ b/pandokia/helpers/runner_unit2.py
@@ -1,7 +1,7 @@
 import sys
 import time
 import traceback
-from ..common import load_source
+from .importer import load_source
 import os.path
 
 no_unittest2 = False

--- a/setup.py
+++ b/setup.py
@@ -271,17 +271,6 @@ if 'install' in d.command_obj:
     print('    ensure that PYTHONPATH is provided by your web server')
     print('')
 
-    import pandokia
-    f = pandokia.cfg.__file__
-    if f.endswith(".pyc") or f.endswith(".pyo"):
-        f = f[:-1]
-    print('The config file is:')
-    print('')
-    print('    %s' % f)
-    print('')
-    print('    you can find the config file at any time with the command "pdk config"')
-    print('')
-
 
 else:
     pass

--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,6 @@ if 'install' in d.command_obj:
     print('')
 
 
-
 else:
     pass
     # print("no install")

--- a/setup.py
+++ b/setup.py
@@ -271,6 +271,18 @@ if 'install' in d.command_obj:
     print('    ensure that PYTHONPATH is provided by your web server')
     print('')
 
+    import pandokia
+    f = pandokia.cfg.__file__
+    if f.endswith(".pyc") or f.endswith(".pyo"):
+        f = f[:-1]
+    print('The config file is:')
+    print('')
+    print('    %s' % f)
+    print('')
+    print('    you can find the config file at any time with the command "pdk config"')
+    print('')
+
+
 
 else:
     pass


### PR DESCRIPTION
On the theory that the circular dependency is at the end of the setup.py file where pandokia setup tries to import pandokia, I tried removing it. Given that it was just loading pandokia to print out the name of this file... I don't think we need it.

This has now been tested by installing this branch on glitch; it worked!