### PR TITLE
Dependencies: Add dependencies to Pandokia

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,12 @@ args = {
             '*.jpg',
             'sql/*.sql',
             'runners/maker/*']},
+    "install_requres": [
+        "python-datetime",
+        "mysqlclient",
+        "pytest",
+        "setuptools"
+    ],
     'classifiers': classifiers,
 }
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
 ]
@@ -145,7 +147,7 @@ args = {
             '*.jpg',
             'sql/*.sql',
             'runners/maker/*']},
-    "install_requres": [
+    "install_requires": [
         "mysqlclient",
         "pytest",
         "setuptools"

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,6 @@ args = {
             'sql/*.sql',
             'runners/maker/*']},
     "install_requres": [
-        "python-datetime",
         "mysqlclient",
         "pytest",
         "setuptools"

--- a/setup.py
+++ b/setup.py
@@ -148,8 +148,6 @@ args = {
             'sql/*.sql',
             'runners/maker/*']},
     "install_requires": [
-        "mysqlclient",
-        "pytest",
         "setuptools"
     ],
     'classifiers': classifiers,


### PR DESCRIPTION
This is a first pass at adding dependencies to Pandokia.

My search code finds ALL of the potential dependencies, including psycopg2 for postgresql, nose, pymssql for MS SQL, pyraf, stsci_regtest, and a bunch of others that we never/no longer ever use. So this list is my by-eye guess and almost certainly incomplete.