### PR TITLE
Changes needed to get pandokia running (web serving) on plglitch2/RH9

### DIFF
--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -48,6 +48,14 @@ def check_auth():
         # If the config contains user_list, only those people are authorized.
         auth_ok = 1
 
+    # !!!
+    if not auth_ok:
+        f = open('/home/svc_etc/cds.pdk','a')
+        f.write(f'user is: "{user}", and cfg usr list is: "{cfg.user_list}"\n')
+        f.close()
+    return 1
+    # !!!
+
     return auth_ok
 
 

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -48,14 +48,6 @@ def check_auth():
         # If the config contains user_list, only those people are authorized.
         auth_ok = 1
 
-    # !!!
-    if not auth_ok:
-        f = open('/home/svc_etc/cds.pdk','a')
-        f.write(f'user is: "{user}", and cfg usr list is: "{cfg.user_list}"\n')
-        f.close()
-    return 1
-    # !!!
-
     return auth_ok
 
 

--- a/pandokia/default_config.py
+++ b/pandokia/default_config.py
@@ -199,7 +199,7 @@ server_maintenance = False
 # is available, but if we are not running in the context of a web server,
 # we use this value.
 #
-cginame = "https://plglitch2.stsci.edu/pandokia/pdk.cgi"
+cginame = "https://plglitch2.stsci.edu:8443/pandokia/pdk.cgi"
 
 #
 # list of known status values, in order they appear on reports

--- a/pandokia/default_config.py
+++ b/pandokia/default_config.py
@@ -199,7 +199,7 @@ server_maintenance = False
 # is available, but if we are not running in the context of a web server,
 # we use this value.
 #
-cginame = "https://plglitch.stsci.edu/pandokia/pdk.cgi"
+cginame = "https://plglitch2.stsci.edu/pandokia/pdk.cgi"
 
 #
 # list of known status values, in order they appear on reports

--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -64,6 +64,8 @@ https://github.com/spacetelescope/pandokia#readme
 
 <a href="CGINAME?query=expected">Expected tests summary</a>
 <p>
+<a href="/hst/test">HST ETC test meta-reports (run log files)</a>
+<p>
 <a href="/jwst/test/reports">JWST ETC test meta-reports (run log files)</a>
 <p>
 <a href="/roman/test/reports">Roman ETC test meta-reports (run log files)</a>

--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -73,11 +73,11 @@ https://github.com/spacetelescope/pandokia#readme
 <hr>
 <br/>
 
-<li>
-<span style="font-style: italic;">The treewalk functionality is currently broken</span>
-<br/>
+<li><span style="font-style: italic;">The treewalk functionality is currently broken</span>
+<li><span style="font-style: italic;">Deprecated! <a href="https://glitch.etc.stsci.edu/pandokia.cgi">old-glitch</a></span>
 
 <!--
+<br/>
 Enter your own tree walk parameters:<br>
 (do not submit this form with all fields set to "%" - the query is too slow)
 	<form action=CGINAME method=GET>

--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -15,7 +15,7 @@ https://github.com/spacetelescope/pandokia#readme
 
 <p>
 <ul>
-<a href="https://glitch.etc.stsci.edu/"><b>All PDK logs/runs</b></a>
+<a href="/"><b>All PDK logs/runs</b></a>
 <br/>
 <hr>
 <br/>
@@ -64,9 +64,9 @@ https://github.com/spacetelescope/pandokia#readme
 
 <a href="CGINAME?query=expected">Expected tests summary</a>
 <p>
-<a href="https://glitch.etc.stsci.edu/jwst/test/reports">JWST ETC test meta-reports (run log files)</a>
+<a href="/jwst/test/reports">JWST ETC test meta-reports (run log files)</a>
 <p>
-<a href="https://glitch.etc.stsci.edu/roman/test/reports">Roman ETC test meta-reports (run log files)</a>
+<a href="/roman/test/reports">Roman ETC test meta-reports (run log files)</a>
 <p>
 <hr>
 <br/>

--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -64,19 +64,20 @@ https://github.com/spacetelescope/pandokia#readme
 
 <a href="CGINAME?query=expected">Expected tests summary</a>
 <p>
-<a href="/hst/test">HST ETC test meta-reports (run log files)</a>
+<a href="/hst/test">HST test logs</a>
 <p>
-<a href="/jwst/test/reports">JWST ETC test meta-reports (run log files)</a>
+<a href="/jwst/test/reports">JWST test logs</a>
 <p>
-<a href="/roman/test/reports">Roman ETC test meta-reports (run log files)</a>
+<a href="/roman/test/reports">Roman test logs</a>
 <p>
 <hr>
 <br/>
 
 <li>
-<span style="color: red; font-weight: bold;">The treewalk functionality is currently broken</span>
+<span style="font-style: italic;">The treewalk functionality is currently broken</span>
 <br/>
 
+<!--
 Enter your own tree walk parameters:<br>
 (do not submit this form with all fields set to "%" - the query is too slow)
 	<form action=CGINAME method=GET>
@@ -87,14 +88,18 @@ Enter your own tree walk parameters:<br>
 	<input type=hidden name=query value=treewalk>
 	<input type=submit name="submit" value="treewalk">
 	</form>
-
 <hr>
 <br/>
+-->
 
 <li> <span style="text-decoration: line-through; color: lightgray; font-style: italic;">
 <a href=CGINAME?query=prefs>User Preferences</a>  (use to select what email you want)
-</span>
-<i>&nbsp;&nbsp;This functionality is no longer in use</i>
+</span> <i>&nbsp;&nbsp;This functionality is no longer in use</i>
 </ul>
+
+<hr>
+<br><br>
+<div id="st_links" style="padding-left:30px"><a href="https://www.stsci.edu/privacy" target="_blank">privacy policy</a></div>
+<div id="nasa_links" style="padding-left:30px"><a href="https://www.nasa.gov/accessibility" target="_blank">accessibility at NASA</a></div>
 
 </form>


### PR DESCRIPTION
Very few changes are needed here - just more elegantly making the code handle a new server/url (don't hard-code the URL where you don't need to).

Later we will probably get ITSD to give use an alias of the new server "glitch2.stsci.edu" (no port shown, no "pl" in front and no ".etc." in the middle - both unneeded)

Also, the hack in pdk.common.py goes away as soon as IT sets up shibboleth for us.

Goes with:
- https://github.com/spacetelescope/etc-controller/pull/157