### PR TITLE
Final changes to server pandokia from plglitch2

### DIFF
--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -48,6 +48,14 @@ def check_auth():
         # If the config contains user_list, only those people are authorized.
         auth_ok = 1
 
+    # !!!
+    if not auth_ok:
+        f = open('/home/svc_etc/cds.pdk','a')
+        f.write(f'user is: "{user}", and cfg usr list is: "{cfg.user_list}"\n')
+        f.close()
+    return 1
+    # !!!
+
     return auth_ok
 
 

--- a/pandokia/common.py
+++ b/pandokia/common.py
@@ -48,14 +48,6 @@ def check_auth():
         # If the config contains user_list, only those people are authorized.
         auth_ok = 1
 
-    # !!!
-    if not auth_ok:
-        f = open('/home/svc_etc/cds.pdk','a')
-        f.write(f'user is: "{user}", and cfg usr list is: "{cfg.user_list}"\n')
-        f.close()
-    return 1
-    # !!!
-
     return auth_ok
 
 

--- a/pandokia/default_config.py
+++ b/pandokia/default_config.py
@@ -199,7 +199,7 @@ server_maintenance = False
 # is available, but if we are not running in the context of a web server,
 # we use this value.
 #
-cginame = "https://plglitch2.stsci.edu:8443/pandokia/pdk.cgi"
+cginame = "https://glitch.stsci.edu/pandokia.cgi"
 
 #
 # list of known status values, in order they appear on reports

--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -64,17 +64,16 @@ https://github.com/spacetelescope/pandokia#readme
 
 <a href="CGINAME?query=expected">Expected tests summary</a>
 <p>
-<a href="/hst/test">HST test logs</a>
+<a href="/hst/test/">HST test logs</a>
 <p>
-<a href="/jwst/test/reports">JWST test logs</a>
+<a href="/jwst/test/reports/">JWST test logs</a>
 <p>
-<a href="/roman/test/reports">Roman test logs</a>
+<a href="/roman/test/reports/">Roman test logs</a>
 <p>
 <hr>
 <br/>
 
 <li><span style="font-style: italic;">The treewalk functionality is currently broken</span>
-<li><span style="font-style: italic;">Deprecated! <a href="https://glitch.etc.stsci.edu/pandokia.cgi">old-glitch</a></span>
 
 <!--
 <br/>


### PR DESCRIPTION
~Use a pdk-login hack until shibboleth is working on plglitch2~

See description in https://jira.stsci.edu/browse/JETC-4794, but IT is now taking care of SSO for us.

All traffic can now go through the rpoxy URL they maintain named:  https://glitch.stsci.edu

Merge along with:  https://github.com/spacetelescope/etc-controller/pull/174