### PR TITLE
DB connect with retry

### DIFF
--- a/pandokia/db_mysqldb.py
+++ b/pandokia/db_mysqldb.py
@@ -13,6 +13,7 @@ __all__ = [
 ]
 
 import MySQLdb as db_module
+import time
 
 # from dbapi
 thread_safe = db_module.threadsafety
@@ -83,7 +84,7 @@ class PandokiaDB(pandokia.db.where_dict_base):
             return
         # NOTREACHED
 
-    def connect_with_retry(self, retry = 2):
+    def connect_with_retry(self, retry = 3):
         # connect to DB with retry on failure 
         # MySQLdb.OperationalError: (2005, "Unknown MySQL server host ...")
         retries = 0
@@ -96,7 +97,7 @@ class PandokiaDB(pandokia.db.where_dict_base):
             except Exception as ex:
                 if retries >= retry:
                     raise ex
-
+            time.sleep(0.5)
         return
 
     def start_transaction(self):

--- a/pandokia/db_mysqldb.py
+++ b/pandokia/db_mysqldb.py
@@ -100,7 +100,7 @@ class PandokiaDB(pandokia.db.where_dict_base):
                 print(str(ex))
                 if retries == max_retries:
                     raise ex
-            time.sleep(0.5)
+            time.sleep(0.05)
         return
 
     def start_transaction(self):

--- a/pandokia/db_mysqldb.py
+++ b/pandokia/db_mysqldb.py
@@ -91,10 +91,13 @@ class PandokiaDB(pandokia.db.where_dict_base):
         while retries < retry:
             retries+=1
             try:
+                if retires == 0: # for testing raise MySQLdb.OperationalError
+                    raise db_module.OperationalError
                 self.db = db_module.connect(** (self.db_access_arg))
                 self.execute("SET autocommit=0")
                 break
             except Exception as ex:
+                print(str(ex))
                 if retries >= retry:
                     raise ex
             time.sleep(0.5)

--- a/pandokia/db_mysqldb.py
+++ b/pandokia/db_mysqldb.py
@@ -91,7 +91,7 @@ class PandokiaDB(pandokia.db.where_dict_base):
         while retries < retry:
             retries+=1
             try:
-                if retires == 0: # for testing raise MySQLdb.OperationalError
+                if retries == 0: # for testing raise MySQLdb.OperationalError
                     raise db_module.OperationalError
                 self.db = db_module.connect(** (self.db_access_arg))
                 self.execute("SET autocommit=0")

--- a/pandokia/db_mysqldb.py
+++ b/pandokia/db_mysqldb.py
@@ -84,21 +84,21 @@ class PandokiaDB(pandokia.db.where_dict_base):
             return
         # NOTREACHED
 
-    def connect_with_retry(self, retry = 3):
+    def connect_with_retry(self, max_retries = 3):
         # connect to DB with retry on failure 
         # MySQLdb.OperationalError: (2005, "Unknown MySQL server host ...")
         retries = 0
-        while retries < retry:
+        while retries < max_retries:
             retries+=1
             try:
-                if retries == 0: # for testing raise MySQLdb.OperationalError
+                if retries <= 2: # for testing raise MySQLdb.OperationalError
                     raise db_module.OperationalError
                 self.db = db_module.connect(** (self.db_access_arg))
                 self.execute("SET autocommit=0")
                 break
             except Exception as ex:
                 print(str(ex))
-                if retries >= retry:
+                if retries == max_retries:
                     raise ex
             time.sleep(0.5)
         return

--- a/pandokia/db_mysqldb.py
+++ b/pandokia/db_mysqldb.py
@@ -91,7 +91,7 @@ class PandokiaDB(pandokia.db.where_dict_base):
         while retries < max_retries:
             retries+=1
             try:
-                if retries <= 2: # for testing raise MySQLdb.OperationalError
+                if retries <= 3: # for testing raise MySQLdb.OperationalError
                     raise db_module.OperationalError
                 self.db = db_module.connect(** (self.db_access_arg))
                 self.execute("SET autocommit=0")


### PR DESCRIPTION

If the db connection fails the third time as well, it would run in to

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/installations/third_party/envs/dev_6/lib/python3.12/site-packages/pandeia/server/sql.py", line 34, in <module>
    db.connect(config.get_db())
  File "/installations/third_party/envs/dev_6/lib/python3.12/site-packages/pandeia/server/database/db.py", line 88, in connect
    self.db.open()
  File "/installations/third_party/envs/dev_6/lib/python3.12/site-packages/pandokia/db_mysqldb.py", line 69, in open
    self.connect_with_retry()
  File "/installations/third_party/envs/dev_6/lib/python3.12/site-packages/pandokia/db_mysqldb.py", line 102, in connect_with_retry
    raise ex
  File "/installations/third_party/envs/dev_6/lib/python3.12/site-packages/pandokia/db_mysqldb.py", line 95, in connect_with_retry
    raise db_module.OperationalError
```