### PR TITLE
Hack to simplify broken versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ match = RE_GIT_DESC.match(version)
 if match is not None:
     shortver, num, commit, dirty_check = match.groups()
     shortver = shortver.split("-")[0]
-    version = f"{shortver}.dev{num}+g{commit}"
+    version = f"{shortver}"
 else:
     version = version.split("-")[0] # just in case -dirty is in the version string
 


### PR DESCRIPTION
Hack to simplify broken versioning.  Right now `pip install .` is broken.

Eventually we should rip out the unused relic-related parts.

We could use some more simplification over the whole ETC software suite, IMO.