### PR TITLE
Change all master branch references to main branch

### DIFF
--- a/extras/stsci/top_level.html
+++ b/extras/stsci/top_level.html
@@ -13,7 +13,7 @@ ADMINLINK
 
 <li> <a href="CGINAME?query=day_report.2&test_run=etc_hst_daily_latest">Latest HST pyetc</a>
 <li> <a href="CGINAME?query=day_report.2&test_run=etc_jwst_daily_latest">Latest Pandeia Report (Local)</a>
-<li> <a href="CGINAME?query=day_report.2&test_run=pandeia_master_latest">Latest Pandeia Report (AWS)</a>
+<li> <a href="CGINAME?query=day_report.2&test_run=pandeia_main_latest">Latest Pandeia Report (AWS)</a>
 <hr>
 
 <li> <a href="CGINAME?query=day_report.1&test_run=-me">Just your test runs</a>

--- a/pandokia/default_config.py
+++ b/pandokia/default_config.py
@@ -263,7 +263,7 @@ recurring_prefix = (
     'etc_jwst_daily',
     'pandeia_nightly',
     'jwst',
-    'pandeia_master_latest'
+    'pandeia_main_latest'
 )
 
 #####

--- a/pandokia/top_level.html
+++ b/pandokia/top_level.html
@@ -20,8 +20,8 @@ https://github.com/spacetelescope/pandokia#readme
 <hr>
 <br/>
 <li> <a href="CGINAME?query=day_report.2&test_run=etc_hst_daily_latest"><b>Latest HST pyetc</b></a>
-<li> <a href="CGINAME?query=day_report.2&test_run=pandeia_jwst_master_latest"><b>Latest JWST Pandeia Report</b></a>
-<li> <a href="CGINAME?query=day_report.2&test_run=pandeia_roman_master_latest"><b>Latest Roman Pandeia Report</b></a>
+<li> <a href="CGINAME?query=day_report.2&test_run=pandeia_jwst_main_latest"><b>Latest JWST Pandeia Report</b></a>
+<li> <a href="CGINAME?query=day_report.2&test_run=pandeia_roman_main_latest"><b>Latest Roman Pandeia Report</b></a>
 
 <br/>
 <hr>


### PR DESCRIPTION
There are some files in question that if they are no longer in use and we should remove them:
- extras/stsci/

Companion PRs: https://github.com/spacetelescope/pandeia/pull/6592, https://github.com/spacetelescope/pandeia_test/pull/2110, https://github.com/spacetelescope/pandeia_data/pull/1152, https://github.com/spacetelescope/pandeia_infra/pull/724, https://github.com/spacetelescope/etc-controller/pull/214

I shall pull master into main once more before we switch.

Address # https://jira.stsci.edu/browse/JETC-5994